### PR TITLE
fix(ipc): bound daemon message reads

### DIFF
--- a/crates/vicaya-cli/src/ipc_client.rs
+++ b/crates/vicaya-cli/src/ipc_client.rs
@@ -1,6 +1,6 @@
 //! IPC client for communicating with the daemon.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Write};
 use std::os::unix::net::UnixStream;
 use vicaya_core::ipc::{Request, Response};
 use vicaya_core::Result;
@@ -40,10 +40,8 @@ impl IpcClient {
 
         // Read response
         let mut reader = BufReader::new(&self.stream);
-        let mut line = String::new();
-        reader
-            .read_line(&mut line)
-            .map_err(|e| vicaya_core::Error::Ipc(format!("Failed to read response: {}", e)))?;
+        let line = vicaya_core::ipc::read_message(&mut reader)?
+            .ok_or_else(|| vicaya_core::Error::Ipc("Daemon closed IPC connection".to_string()))?;
 
         Response::from_json(&line)
             .map_err(|e| vicaya_core::Error::Ipc(format!("Failed to parse response: {}", e)))

--- a/crates/vicaya-core/src/daemon.rs
+++ b/crates/vicaya-core/src/daemon.rs
@@ -245,7 +245,7 @@ fn wait_for_daemon_ready(pid: i32) -> crate::Result<()> {
 fn request_shutdown_via_ipc() -> crate::Result<()> {
     #[cfg(unix)]
     {
-        use std::io::{BufRead, BufReader, Write};
+        use std::io::{BufReader, Write};
         use std::os::unix::net::UnixStream;
 
         let mut stream = UnixStream::connect(crate::ipc::socket_path())
@@ -261,8 +261,7 @@ fn request_shutdown_via_ipc() -> crate::Result<()> {
             .map_err(|e| crate::Error::Ipc(format!("Failed to send request: {}", e)))?;
 
         let mut reader = BufReader::new(stream);
-        let mut line = String::new();
-        let _ = reader.read_line(&mut line);
+        let _ = crate::ipc::read_message(&mut reader);
         Ok(())
     }
 

--- a/crates/vicaya-core/src/ipc.rs
+++ b/crates/vicaya-core/src/ipc.rs
@@ -1,6 +1,13 @@
 //! IPC protocol for daemon communication.
 
+use std::io::BufRead;
+
 use serde::{Deserialize, Serialize};
+
+use crate::{Error, Result};
+
+/// Maximum newline-delimited IPC message size in bytes.
+pub const MAX_IPC_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Build metadata for a running daemon or client.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -108,6 +115,51 @@ impl Response {
     }
 }
 
+/// Read one newline-delimited IPC message without unbounded allocation.
+///
+/// Returns `Ok(None)` on clean EOF before any bytes are read. If EOF arrives
+/// after some bytes but before a newline, the partial message is returned so
+/// callers can decide whether it is valid.
+pub fn read_message<R: BufRead>(reader: &mut R) -> Result<Option<String>> {
+    let mut message = Vec::new();
+
+    loop {
+        let available = reader
+            .fill_buf()
+            .map_err(|e| Error::Ipc(format!("Failed to read IPC message: {}", e)))?;
+
+        if available.is_empty() {
+            if message.is_empty() {
+                return Ok(None);
+            }
+            return String::from_utf8(message)
+                .map(Some)
+                .map_err(|e| Error::Ipc(format!("IPC message was not valid UTF-8: {}", e)));
+        }
+
+        let take = match available.iter().position(|&byte| byte == b'\n') {
+            Some(newline_idx) => newline_idx + 1,
+            None => available.len(),
+        };
+
+        if message.len() + take > MAX_IPC_MESSAGE_BYTES {
+            return Err(Error::Ipc(format!(
+                "IPC message exceeds {} bytes",
+                MAX_IPC_MESSAGE_BYTES
+            )));
+        }
+
+        message.extend_from_slice(&available[..take]);
+        reader.consume(take);
+
+        if take > 0 && message.last() == Some(&b'\n') {
+            return String::from_utf8(message)
+                .map(Some)
+                .map_err(|e| Error::Ipc(format!("IPC message was not valid UTF-8: {}", e)));
+        }
+    }
+}
+
 /// Get the socket path for IPC communication.
 pub fn socket_path() -> std::path::PathBuf {
     crate::paths::socket_path()
@@ -115,6 +167,8 @@ pub fn socket_path() -> std::path::PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use std::io::BufReader;
+
     use super::*;
 
     #[test]
@@ -236,5 +290,36 @@ mod tests {
         assert_eq!(result.score, 1.0);
         assert_eq!(result.size, 2048);
         assert_eq!(result.mtime, 1234567890);
+    }
+
+    #[test]
+    fn test_read_message_under_limit_with_newline() {
+        let mut reader = BufReader::new(&b"{\"type\":\"status\"}\n"[..]);
+        let message = read_message(&mut reader).unwrap();
+        assert_eq!(message.as_deref(), Some("{\"type\":\"status\"}\n"));
+    }
+
+    #[test]
+    fn test_read_message_under_limit_without_newline() {
+        let mut reader = BufReader::new(&b"{\"type\":\"status\"}"[..]);
+        let message = read_message(&mut reader).unwrap();
+        assert_eq!(message.as_deref(), Some("{\"type\":\"status\"}"));
+    }
+
+    #[test]
+    fn test_read_message_rejects_payload_over_limit_without_newline() {
+        let oversized = vec![b'a'; MAX_IPC_MESSAGE_BYTES + 1];
+        let mut reader = BufReader::new(oversized.as_slice());
+        let err = read_message(&mut reader).unwrap_err();
+        assert!(matches!(err, Error::Ipc(message) if message.contains("exceeds")));
+    }
+
+    #[test]
+    fn test_read_message_rejects_payload_over_limit_before_newline() {
+        let mut oversized = vec![b'a'; MAX_IPC_MESSAGE_BYTES];
+        oversized.push(b'\n');
+        let mut reader = BufReader::new(oversized.as_slice());
+        let err = read_message(&mut reader).unwrap_err();
+        assert!(matches!(err, Error::Ipc(message) if message.contains("exceeds")));
     }
 }

--- a/crates/vicaya-daemon/src/ipc_server.rs
+++ b/crates/vicaya-daemon/src/ipc_server.rs
@@ -2,7 +2,7 @@
 
 use std::collections::hash_map::RandomState;
 use std::hash::BuildHasher;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -786,11 +786,9 @@ impl IpcServer {
         debug!("Client connected: {:?}", peer_addr);
 
         let mut reader = BufReader::new(stream.try_clone().unwrap());
-        let mut line = String::new();
-
-        match reader.read_line(&mut line) {
-            Ok(0) => debug!("Client disconnected"),
-            Ok(_) => {
+        match vicaya_core::ipc::read_message(&mut reader) {
+            Ok(None) => debug!("Client disconnected"),
+            Ok(Some(line)) => {
                 let request = match Request::from_json(&line) {
                     Ok(req) => req,
                     Err(e) => {
@@ -807,7 +805,13 @@ impl IpcServer {
                 let response = self.handle_request(request);
                 self.send_response(&mut stream, &response);
             }
-            Err(e) => error!("Failed to read from client: {}", e),
+            Err(e) => {
+                error!("Failed to read from client: {}", e);
+                let response = Response::Error {
+                    message: e.to_string(),
+                };
+                self.send_response(&mut stream, &response);
+            }
         }
     }
 

--- a/crates/vicaya-daemon/tests/ipc_large_response.rs
+++ b/crates/vicaya-daemon/tests/ipc_large_response.rs
@@ -1,4 +1,5 @@
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Write};
+use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
@@ -6,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use tempfile::tempdir;
 use vicaya_core::config::PerformanceConfig;
-use vicaya_core::ipc::{Request, Response};
+use vicaya_core::ipc::{Request, Response, MAX_IPC_MESSAGE_BYTES};
 use vicaya_core::Config;
 
 struct DaemonChild(Child);
@@ -39,8 +40,9 @@ fn ipc_request(socket: &Path, req: &Request) -> Response {
         .expect("Should write request");
 
     let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    reader.read_line(&mut line).expect("Should read response");
+    let line = vicaya_core::ipc::read_message(&mut reader)
+        .expect("Should read response")
+        .expect("Should receive response");
     Response::from_json(&line).expect("Should parse response")
 }
 
@@ -104,6 +106,102 @@ fn it_handles_large_search_responses_without_truncation() {
             );
         }
         other => panic!("unexpected response: {:?}", other),
+    }
+
+    let _ = ipc_request(&socket, &Request::Shutdown);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(Some(_)) = child.0.try_wait() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    panic!("Daemon did not shut down within timeout");
+}
+
+#[test]
+fn it_rejects_oversized_requests_and_stays_responsive() {
+    let vicaya_dir = tempdir().unwrap();
+    let root = tempdir().unwrap();
+
+    std::fs::write(root.path().join("healthy.txt"), "").unwrap();
+
+    let config = Config {
+        index_roots: vec![root.path().to_path_buf()],
+        exclusions: vec![],
+        index_path: vicaya_dir.path().join("index"),
+        max_memory_mb: 128,
+        performance: PerformanceConfig {
+            scanner_threads: 2,
+            reconcile_hour: 3,
+        },
+    };
+
+    std::fs::create_dir_all(vicaya_dir.path()).unwrap();
+    config.save(&vicaya_dir.path().join("config.toml")).unwrap();
+    config.ensure_index_dir().unwrap();
+
+    let daemon_bin = env!("CARGO_BIN_EXE_vicaya-daemon");
+    let mut child = DaemonChild(
+        Command::new(daemon_bin)
+            .env("VICAYA_DIR", vicaya_dir.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap(),
+    );
+
+    let socket = vicaya_dir.path().join("daemon.sock");
+    wait_for_socket(&socket, Duration::from_secs(10));
+
+    let mut malicious = UnixStream::connect(&socket).expect("Should connect malformed client");
+    let oversized = vec![b'a'; MAX_IPC_MESSAGE_BYTES + 1];
+    malicious
+        .write_all(&oversized)
+        .expect("Should write oversized payload");
+    malicious
+        .shutdown(Shutdown::Write)
+        .expect("Should close malformed writer");
+
+    let mut response_reader = BufReader::new(malicious);
+    let line = vicaya_core::ipc::read_message(&mut response_reader)
+        .expect("Daemon should respond to oversized payload")
+        .expect("Daemon should emit an error response");
+    let response = Response::from_json(&line).expect("Oversized response should be valid JSON");
+    match response {
+        Response::Error { message } => {
+            assert!(
+                message.contains("exceeds"),
+                "expected oversize error, got {message}"
+            );
+        }
+        other => panic!("unexpected malformed-client response: {:?}", other),
+    }
+
+    let healthy = ipc_request(
+        &socket,
+        &Request::Search {
+            query: "healthy.txt".to_string(),
+            limit: 10,
+            scope: None,
+            recent_if_empty: false,
+        },
+    );
+
+    match healthy {
+        Response::SearchResults { results } => {
+            assert!(
+                results.iter().any(|r| r.path.ends_with("healthy.txt")),
+                "expected daemon to remain responsive after malformed client"
+            );
+        }
+        other => panic!(
+            "unexpected healthy response after malformed client: {:?}",
+            other
+        ),
     }
 
     let _ = ipc_request(&socket, &Request::Shutdown);

--- a/crates/vicaya-daemon/tests/startup_reconcile.rs
+++ b/crates/vicaya-daemon/tests/startup_reconcile.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
@@ -40,8 +40,9 @@ fn ipc_request(socket: &Path, req: &Request) -> Response {
         .expect("Should write request");
 
     let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    reader.read_line(&mut line).expect("Should read response");
+    let line = vicaya_core::ipc::read_message(&mut reader)
+        .expect("Should read response")
+        .expect("Should receive response");
     Response::from_json(&line).expect("Should parse response")
 }
 

--- a/crates/vicaya-tui/src/client/mod.rs
+++ b/crates/vicaya-tui/src/client/mod.rs
@@ -1,6 +1,6 @@
 //! IPC client for communicating with the daemon.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Write};
 use std::os::unix::net::UnixStream;
 use vicaya_core::ipc::{Request, Response};
 use vicaya_index::SearchResult;
@@ -149,10 +149,8 @@ impl IpcClient {
 
         // Read response
         let mut reader = BufReader::new(stream);
-        let mut line = String::new();
-        reader
-            .read_line(&mut line)
-            .map_err(|e| anyhow::anyhow!("Failed to read response: {}", e))?;
+        let line = vicaya_core::ipc::read_message(&mut reader)?
+            .ok_or_else(|| anyhow::anyhow!("Daemon closed IPC connection"))?;
 
         Response::from_json(&line).map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))
     }

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -13,6 +13,7 @@ This document captures execution-time learnings that should be applied to every 
 
 ## iTerm2 Automation Guardrails
 
+- Run iTerm2 automation serially. Parallel runs fight over window focus, tab/session IDs, and key delivery, which makes failures non-deterministic even when the product is healthy.
 - `session.async_send_text(...)` is reliable for plain text, `Esc`, arrow keys, and most ordinary navigation.
 - Control-chord delivery is not equally reliable. `Ctrl+O` is especially suspect in terminal automation because tty discard handling can intercept it before the TUI sees it.
 - `stty discard undef` should be set before launching `vicaya-tui`, but that does not guarantee every control chord will be delivered consistently.


### PR DESCRIPTION
## Summary
- add a shared bounded newline-delimited IPC reader in `vicaya-core`
- migrate daemon, CLI, TUI, and daemon shutdown paths to the bounded reader
- add regression coverage for oversized malformed requests and record the serial iTerm2 automation rule

## Validation
- `cargo test -p vicaya-core --lib`
- `cargo test -p vicaya-daemon --test ipc_large_response --test startup_reconcile`
- `cargo test -p vicaya-cli --test ranking_cli_smoke`
- `cargo test -p vicaya-tui --lib`
- `uv run .claude/automations/test_vicaya_tui_core_visual.py`
- `uv run .claude/automations/test_vicaya_tui_scope_navigation.py`

Closes #15
