### PR TITLE
fix(daemon): skip stale startup journal replay

### DIFF
--- a/crates/vicaya-daemon/src/main.rs
+++ b/crates/vicaya-daemon/src/main.rs
@@ -55,8 +55,13 @@ fn main() -> Result<()> {
         snapshot,
     )));
 
-    // Replay journal (if any) to ensure we don't lose updates across restarts.
-    replay_journal(&state, &journal_file)?;
+    // Fresh scans are authoritative. Only replay downtime journal entries when we had an
+    // existing on-disk snapshot to reconcile against.
+    if had_index {
+        replay_journal(&state, &journal_file)?;
+    } else {
+        clear_stale_journal(&journal_file)?;
+    }
 
     let shutdown = Arc::new(AtomicBool::new(false));
     let journal_lock = Arc::new(Mutex::new(()));
@@ -166,6 +171,24 @@ fn replay_journal(state: &SharedState, journal_file: &Path) -> Result<()> {
     if applied > 0 {
         info!("Replayed {} journal updates", applied);
     }
+    Ok(())
+}
+
+fn clear_stale_journal(journal_file: &Path) -> Result<()> {
+    if !journal_file.exists() {
+        return Ok(());
+    }
+
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(journal_file)?;
+    drop(file);
+
+    info!(
+        "Discarded stale journal history after fresh index build: {}",
+        journal_file.display()
+    );
     Ok(())
 }
 

--- a/crates/vicaya-daemon/tests/startup_reconcile.rs
+++ b/crates/vicaya-daemon/tests/startup_reconcile.rs
@@ -9,6 +9,7 @@ use vicaya_core::config::PerformanceConfig;
 use vicaya_core::ipc::{Request, Response};
 use vicaya_core::Config;
 use vicaya_scanner::Scanner;
+use vicaya_watcher::IndexUpdate;
 
 struct DaemonChild(Child);
 
@@ -44,6 +45,19 @@ fn ipc_request(socket: &Path, req: &Request) -> Response {
         .expect("Should read response")
         .expect("Should receive response");
     Response::from_json(&line).expect("Should parse response")
+}
+
+fn append_journal_updates(journal: &Path, updates: &[IndexUpdate]) {
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(journal)
+        .expect("Should open journal");
+
+    for update in updates {
+        let json = serde_json::to_string(update).expect("Should serialize update");
+        writeln!(file, "{json}").expect("Should append journal update");
+    }
 }
 
 #[test]
@@ -114,6 +128,161 @@ fn it_indexes_offline_changes_via_startup_reconcile() {
 
         std::thread::sleep(Duration::from_millis(50));
     }
+
+    let _ = ipc_request(&socket, &Request::Shutdown);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(Some(_)) = child.0.try_wait() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    panic!("Daemon did not shut down within timeout");
+}
+
+#[test]
+fn it_replays_journal_when_starting_from_existing_index() {
+    let vicaya_dir = tempdir().unwrap();
+    let root = tempdir().unwrap();
+
+    let config = Config {
+        index_roots: vec![root.path().to_path_buf()],
+        exclusions: vec![],
+        index_path: vicaya_dir.path().join("index"),
+        max_memory_mb: 128,
+        performance: PerformanceConfig {
+            scanner_threads: 2,
+            reconcile_hour: 3,
+        },
+    };
+
+    std::fs::create_dir_all(vicaya_dir.path()).unwrap();
+    config.save(&vicaya_dir.path().join("config.toml")).unwrap();
+    config.ensure_index_dir().unwrap();
+
+    std::fs::write(root.path().join("before.txt"), "").unwrap();
+    let scanner = Scanner::new(config.clone());
+    let snapshot = scanner.scan().unwrap();
+    snapshot.save(&config.index_path.join("index.bin")).unwrap();
+
+    let after = root.path().join("after.txt");
+    std::fs::write(&after, "").unwrap();
+    append_journal_updates(
+        &config.index_path.join("index.journal"),
+        &[IndexUpdate::Create {
+            path: after.to_string_lossy().to_string(),
+        }],
+    );
+
+    let daemon_bin = env!("CARGO_BIN_EXE_vicaya-daemon");
+    let mut child = DaemonChild(
+        Command::new(daemon_bin)
+            .env("VICAYA_DIR", vicaya_dir.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap(),
+    );
+
+    let socket = vicaya_dir.path().join("daemon.sock");
+    wait_for_socket(&socket, Duration::from_secs(10));
+
+    let response = ipc_request(
+        &socket,
+        &Request::Search {
+            query: "after.txt".to_string(),
+            limit: 20,
+            scope: None,
+            recent_if_empty: false,
+        },
+    );
+
+    match response {
+        Response::SearchResults { results } => {
+            assert!(results.iter().any(|r| r.path.ends_with("after.txt")));
+        }
+        other => panic!("unexpected response: {:?}", other),
+    }
+
+    let _ = ipc_request(&socket, &Request::Shutdown);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(Some(_)) = child.0.try_wait() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    panic!("Daemon did not shut down within timeout");
+}
+
+#[test]
+fn it_discards_stale_journal_when_starting_from_fresh_build() {
+    let vicaya_dir = tempdir().unwrap();
+    let root = tempdir().unwrap();
+
+    let config = Config {
+        index_roots: vec![root.path().to_path_buf()],
+        exclusions: vec![],
+        index_path: vicaya_dir.path().join("index"),
+        max_memory_mb: 128,
+        performance: PerformanceConfig {
+            scanner_threads: 2,
+            reconcile_hour: 3,
+        },
+    };
+
+    std::fs::create_dir_all(vicaya_dir.path()).unwrap();
+    config.save(&vicaya_dir.path().join("config.toml")).unwrap();
+    config.ensure_index_dir().unwrap();
+
+    let live = root.path().join("live.txt");
+    std::fs::write(&live, "").unwrap();
+    let journal = config.index_path.join("index.journal");
+    append_journal_updates(
+        &journal,
+        &[IndexUpdate::Delete {
+            path: live.to_string_lossy().to_string(),
+        }],
+    );
+
+    let daemon_bin = env!("CARGO_BIN_EXE_vicaya-daemon");
+    let mut child = DaemonChild(
+        Command::new(daemon_bin)
+            .env("VICAYA_DIR", vicaya_dir.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap(),
+    );
+
+    let socket = vicaya_dir.path().join("daemon.sock");
+    wait_for_socket(&socket, Duration::from_secs(10));
+
+    let response = ipc_request(
+        &socket,
+        &Request::Search {
+            query: "live.txt".to_string(),
+            limit: 20,
+            scope: None,
+            recent_if_empty: false,
+        },
+    );
+
+    match response {
+        Response::SearchResults { results } => {
+            assert!(results.iter().any(|r| r.path.ends_with("live.txt")));
+        }
+        other => panic!("unexpected response: {:?}", other),
+    }
+
+    let journal_len = std::fs::metadata(&journal).unwrap().len();
+    assert_eq!(journal_len, 0, "fresh build should truncate stale journal");
 
     let _ = ipc_request(&socket, &Request::Shutdown);
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -71,3 +71,8 @@ This document captures execution-time learnings that should be applied to every 
   3. clean resident `vicaya` processes
   4. verify versions
   5. only then run iTerm2 automation
+- PR merge gate:
+  1. wait for CI to finish
+  2. wait for Codex review to settle as well
+  3. only merge after Codex has either reduced to a `👍`/non-actionable settled state or after any real Codex comments have been fixed and resolved
+  4. do not treat "green CI + no current threads" as sufficient if Codex is still actively reviewing


### PR DESCRIPTION
## Summary
- skip stale journal replay when startup had to build a fresh snapshot
- preserve journal replay when starting from an existing on-disk index
- document the stricter Codex review settle gate in shared learnings

## Validation
- `cargo test -p vicaya-daemon`
- `cargo test -p vicaya-daemon --test startup_reconcile --test ipc_large_response`
- `uv run .claude/automations/test_vicaya_tui_core_visual.py`
- `uv run .claude/automations/test_vicaya_tui_scope_navigation.py`

Closes #20
