### PR TITLE
fix(config): normalize exclusion patterns

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -5,13 +5,13 @@ index_roots = ["~"]
 
 # Paths to exclude from indexing
 exclusions = [
-    "/System",
-    "/Library",
-    "/.git",
-    "/node_modules",
-    "/target",
-    "/.cargo",
-    "/.rustup",
+    "System",
+    "Library",
+    ".git",
+    "node_modules",
+    "target",
+    ".cargo",
+    ".rustup",
 ]
 
 # Path to store the index data

--- a/crates/vicaya-core/src/config.rs
+++ b/crates/vicaya-core/src/config.rs
@@ -34,16 +34,16 @@ pub struct PerformanceConfig {
 
 impl Default for Config {
     fn default() -> Self {
-        Self {
+        let mut config = Self {
             index_roots: vec![PathBuf::from(
                 std::env::var("HOME").unwrap_or_else(|_| "/".to_string()),
             )],
             exclusions: vec![
-                "/System".to_string(),
-                "/Library".to_string(),
-                "/.git".to_string(),
-                "/node_modules".to_string(),
-                "/target".to_string(),
+                "System".to_string(),
+                "Library".to_string(),
+                ".git".to_string(),
+                "node_modules".to_string(),
+                "target".to_string(),
             ],
             index_path: Self::default_index_path(),
             max_memory_mb: 512,
@@ -51,7 +51,9 @@ impl Default for Config {
                 scanner_threads: num_cpus::get(),
                 reconcile_hour: 3,
             },
-        }
+        };
+        config.normalize_exclusions();
+        config
     }
 }
 
@@ -64,6 +66,7 @@ impl Config {
 
         // Expand tilde (~) and environment variables in paths using shellexpand
         config.expand_paths();
+        config.normalize_exclusions();
 
         Ok(config)
     }
@@ -79,6 +82,14 @@ impl Config {
 
         // Expand in index_path
         self.index_path = Self::expand_path(&self.index_path);
+    }
+
+    fn normalize_exclusions(&mut self) {
+        self.exclusions = self
+            .exclusions
+            .iter()
+            .map(|exclusion| crate::filter::normalize_exclusion(exclusion).to_string())
+            .collect();
     }
 
     /// Expand tilde and environment variables in a single path.
@@ -199,6 +210,7 @@ reconcile_hour = 3
 
         assert!(!config.index_roots.is_empty());
         assert!(!config.exclusions.is_empty());
+        assert!(config.exclusions.iter().all(|ex| !ex.starts_with('/')));
         assert_eq!(config.max_memory_mb, 512);
         assert_eq!(config.performance.reconcile_hour, 3);
     }
@@ -239,5 +251,29 @@ reconcile_hour = 3
             loaded_config.performance.reconcile_hour,
             config.performance.reconcile_hour
         );
+    }
+
+    #[test]
+    fn test_load_normalizes_leading_slash_exclusions() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let config_content = r#"
+index_roots = ["~"]
+exclusions = ["/target", "/node_modules", "/*.log"]
+index_path = "~/Library/Application Support/vicaya"
+max_memory_mb = 512
+
+[performance]
+scanner_threads = 4
+reconcile_hour = 3
+"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(config_content.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = Config::load(temp_file.path()).unwrap();
+        assert_eq!(config.exclusions, vec!["target", "node_modules", "*.log"]);
     }
 }

--- a/crates/vicaya-core/src/filter.rs
+++ b/crates/vicaya-core/src/filter.rs
@@ -2,6 +2,11 @@
 
 use std::path::Path;
 
+/// Normalize exclusion patterns to the component-oriented matching model.
+pub fn normalize_exclusion(exclusion: &str) -> &str {
+    exclusion.trim_start_matches('/')
+}
+
 /// Return `true` if a path should be indexed given the configured exclusions.
 ///
 /// Exclusions are matched against individual path components. Supports:
@@ -11,6 +16,7 @@ use std::path::Path;
 ///   - `prefix*` (prefix match)
 pub fn should_index_path(path: &Path, exclusions: &[String]) -> bool {
     for exclusion in exclusions {
+        let exclusion = normalize_exclusion(exclusion);
         for component in path.components() {
             if matches!(component, std::path::Component::RootDir) {
                 continue;
@@ -28,7 +34,7 @@ pub fn should_index_path(path: &Path, exclusions: &[String]) -> bool {
                         return false;
                     }
                 }
-            } else if component_str == exclusion.as_str() {
+            } else if component_str == exclusion {
                 return false;
             }
         }

--- a/crates/vicaya-scanner/src/lib.rs
+++ b/crates/vicaya-scanner/src/lib.rs
@@ -303,6 +303,26 @@ mod tests {
     }
 
     #[test]
+    fn test_should_index_leading_slash_exclusions() {
+        let scanner = make_scanner(vec!["/target".to_string(), "/node_modules".to_string()]);
+
+        assert!(!scanner.should_index(Path::new("/rust/project/target/debug/app")));
+        assert!(!scanner.should_index(Path::new(
+            "/home/user/project/node_modules/package/index.js"
+        )));
+        assert!(scanner.should_index(Path::new("/home/user/project/src/main.rs")));
+    }
+
+    #[test]
+    fn test_should_index_leading_slash_globs() {
+        let scanner = make_scanner(vec!["/*.log".to_string(), "/._*".to_string()]);
+
+        assert!(!scanner.should_index(Path::new("/var/log/app.log")));
+        assert!(!scanner.should_index(Path::new("/Users/test/._secret")));
+        assert!(scanner.should_index(Path::new("/Users/test/app.rs")));
+    }
+
+    #[test]
     fn test_should_index_multiple_exclusions() {
         let scanner = make_scanner(vec![
             ".git".to_string(),


### PR DESCRIPTION
## Summary
- normalize exclusion patterns so `/target` and `target` match the same path components
- normalize loaded/default config values and update default config entries to slashless forms
- add regression coverage for leading-slash exact and glob exclusions

## Validation
- `cargo test -p vicaya-core --lib`
- `cargo test -p vicaya-scanner --lib`
- `cargo test -p vicaya-cli --test ranking_cli_smoke`
- `uv run .claude/automations/test_vicaya_tui_core_visual.py`

Closes #18
