### PR TITLE
fix(watcher): trust ordered rename pairs

### DIFF
--- a/crates/vicaya-watcher/src/lib.rs
+++ b/crates/vicaya-watcher/src/lib.rs
@@ -87,34 +87,8 @@ impl FileWatcher {
                         path: p.to_string_lossy().to_string(),
                     })
                     .collect(),
-                RenameMode::Both | RenameMode::Any | RenameMode::Other => {
-                    let paths = event.paths;
-                    if paths.len() == 2 {
-                        let mut paths = paths;
-                        let second = paths.pop().unwrap();
-                        let first = paths.pop().unwrap();
-
-                        let (from, to) = match (first.exists(), second.exists()) {
-                            (false, true) => (first, second),
-                            (true, false) => (second, first),
-                            _ => (first, second),
-                        };
-
-                        vec![IndexUpdate::Move {
-                            from: from.to_string_lossy().to_string(),
-                            to: to.to_string_lossy().to_string(),
-                        }]
-                    } else {
-                        // Some backends may emit a rename without both endpoints. Upsert whatever
-                        // paths we have as a best-effort; the daemon can dedupe by inode.
-                        paths
-                            .into_iter()
-                            .map(|p| IndexUpdate::Modify {
-                                path: p.to_string_lossy().to_string(),
-                            })
-                            .collect()
-                    }
-                }
+                RenameMode::Both => Self::ordered_move_update(event.paths),
+                RenameMode::Any | RenameMode::Other => Self::heuristic_move_update(event.paths),
             },
             EventKind::Modify(_) => event
                 .paths
@@ -133,6 +107,45 @@ impl FileWatcher {
             _ => Vec::new(),
         }
     }
+
+    fn ordered_move_update(paths: Vec<std::path::PathBuf>) -> Vec<IndexUpdate> {
+        match paths.as_slice() {
+            [from, to] => vec![IndexUpdate::Move {
+                from: from.to_string_lossy().to_string(),
+                to: to.to_string_lossy().to_string(),
+            }],
+            _ => Self::best_effort_modify_updates(paths),
+        }
+    }
+
+    fn heuristic_move_update(paths: Vec<std::path::PathBuf>) -> Vec<IndexUpdate> {
+        match paths.as_slice() {
+            [first, second] => {
+                let (from, to) = match (first.exists(), second.exists()) {
+                    (false, true) => (first, second),
+                    (true, false) => (second, first),
+                    _ => (first, second),
+                };
+
+                vec![IndexUpdate::Move {
+                    from: from.to_string_lossy().to_string(),
+                    to: to.to_string_lossy().to_string(),
+                }]
+            }
+            _ => Self::best_effort_modify_updates(paths),
+        }
+    }
+
+    fn best_effort_modify_updates(paths: Vec<std::path::PathBuf>) -> Vec<IndexUpdate> {
+        // Some backends may emit a rename without both endpoints. Upsert whatever
+        // paths we have as a best-effort; the daemon can dedupe by inode.
+        paths
+            .into_iter()
+            .map(|p| IndexUpdate::Modify {
+                path: p.to_string_lossy().to_string(),
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -142,17 +155,17 @@ mod tests {
     use notify::EventKind;
 
     #[test]
-    fn rename_both_uses_existing_path_as_destination() {
+    fn rename_both_trusts_ordered_pair() {
         let dir = tempfile::tempdir().unwrap();
         let from = dir.path().join("old_name.txt");
         let to = dir.path().join("new_name.txt");
 
-        // Simulate post-rename state: destination exists, source does not.
+        std::fs::write(&from, "").unwrap();
         std::fs::write(&to, "").unwrap();
 
         let event = notify::Event {
             kind: EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
-            paths: vec![to.clone(), from.clone()],
+            paths: vec![from.clone(), to.clone()],
             attrs: Default::default(),
         };
 
@@ -171,5 +184,99 @@ mod tests {
             to.display(),
             updates
         );
+    }
+
+    #[test]
+    fn rename_both_preserves_reported_order_even_if_paths_look_reversed() {
+        let dir = tempfile::tempdir().unwrap();
+        let from = dir.path().join("old_name.txt");
+        let to = dir.path().join("new_name.txt");
+
+        // Simulate post-rename state: destination exists, source does not. For
+        // RenameMode::Both we still trust the ordered pair supplied by notify.
+        std::fs::write(&to, "").unwrap();
+
+        let event = notify::Event {
+            kind: EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+            paths: vec![to.clone(), from.clone()],
+            attrs: Default::default(),
+        };
+
+        let updates = FileWatcher::event_to_updates(event);
+        let reported_from = to.to_string_lossy().to_string();
+        let reported_to = from.to_string_lossy().to_string();
+
+        assert_eq!(updates.len(), 1);
+        assert!(
+            matches!(
+                &updates[0],
+                IndexUpdate::Move { from, to } if from == &reported_from && to == &reported_to
+            ),
+            "expected Move from={} to={} without heuristic correction, got: {:?}",
+            to.display(),
+            from.display(),
+            updates
+        );
+    }
+
+    #[test]
+    fn rename_any_uses_existence_heuristic_for_direction() {
+        let dir = tempfile::tempdir().unwrap();
+        let from = dir.path().join("old_name.txt");
+        let to = dir.path().join("new_name.txt");
+
+        std::fs::write(&to, "").unwrap();
+
+        let event = notify::Event {
+            kind: EventKind::Modify(ModifyKind::Name(RenameMode::Any)),
+            paths: vec![to.clone(), from.clone()],
+            attrs: Default::default(),
+        };
+
+        let updates = FileWatcher::event_to_updates(event);
+        let from_str = from.to_string_lossy().to_string();
+        let to_str = to.to_string_lossy().to_string();
+
+        assert_eq!(updates.len(), 1);
+        assert!(
+            matches!(
+                &updates[0],
+                IndexUpdate::Move { from: f, to: t } if f == &from_str && t == &to_str
+            ),
+            "expected heuristic Move from={} to={}, got: {:?}",
+            from.display(),
+            to.display(),
+            updates
+        );
+    }
+
+    #[test]
+    fn rename_other_with_ambiguous_paths_falls_back_to_modify() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.txt");
+        let second = dir.path().join("second.txt");
+        let third = dir.path().join("third.txt");
+
+        let event = notify::Event {
+            kind: EventKind::Modify(ModifyKind::Name(RenameMode::Other)),
+            paths: vec![first.clone(), second.clone(), third.clone()],
+            attrs: Default::default(),
+        };
+
+        let updates = FileWatcher::event_to_updates(event);
+        let expected: Vec<String> = vec![first, second, third]
+            .into_iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(updates.len(), 3);
+        for (update, path) in updates.iter().zip(expected.iter()) {
+            assert!(
+                matches!(update, IndexUpdate::Modify { path: candidate } if candidate == path),
+                "expected Modify for {}, got: {:?}",
+                path,
+                update
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- split rename handling so `RenameMode::Both` trusts the ordered `[from, to]` pair from notify
- keep the existence heuristic only for ambiguous `RenameMode::Any` / `RenameMode::Other` cases
- add regression tests for ordered pairs, deliberately reversed `Both` input, and ambiguous-path fallback behavior

Closes #19

## Validation
- cargo test -p vicaya-watcher
- uv run .claude/automations/test_vicaya_tui_core_visual.py
