### PR TITLE
test: raise coverage to 85

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -80,6 +80,7 @@ jobs:
 
             > This is a preview release for testing purposes only.
             > It will be automatically deleted after 7 days.
+          draft: true
           prerelease: true
           files: |
             dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ Cargo.lock
 
 # Test artifacts
 /tests/fixtures/generated/
+.codemap/
+*.log
 
 # Benchmark tools
 hyperfine*

--- a/crates/vicaya-cli/src/metrics.rs
+++ b/crates/vicaya-cli/src/metrics.rs
@@ -1447,6 +1447,29 @@ fn format_us(us: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set_path(key: &'static str, value: &Path) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     fn build_info() -> BuildInfo {
         BuildInfo {
@@ -1672,8 +1695,7 @@ TOTAL                             950.0M      2464K      2464K         0K      1
     fn snapshot_collection_handles_absent_daemon_without_failing() {
         let _lock = vicaya_core::paths::test_env_lock();
         let dir = tempfile::tempdir().unwrap();
-        let old_vicaya_dir = std::env::var_os("VICAYA_DIR");
-        std::env::set_var("VICAYA_DIR", dir.path());
+        let _vicaya_dir_guard = EnvVarGuard::set_path("VICAYA_DIR", dir.path());
 
         let ctx = build_snapshot_context().unwrap();
         let snapshot = collect_snapshot(
@@ -1690,11 +1712,6 @@ TOTAL                             950.0M      2464K      2464K         0K      1
             .notes
             .iter()
             .any(|note| note.contains("Daemon is not running")));
-
-        match old_vicaya_dir {
-            Some(value) => std::env::set_var("VICAYA_DIR", value),
-            None => std::env::remove_var("VICAYA_DIR"),
-        }
     }
 
     #[test]
@@ -1756,8 +1773,7 @@ TOTAL                             950.0M      2464K      2464K         0K      1
     fn watch_metrics_supports_bounded_jsonl_and_rejects_bad_interval() {
         let _lock = vicaya_core::paths::test_env_lock();
         let dir = tempfile::tempdir().unwrap();
-        let old_vicaya_dir = std::env::var_os("VICAYA_DIR");
-        std::env::set_var("VICAYA_DIR", dir.path());
+        let _vicaya_dir_guard = EnvVarGuard::set_path("VICAYA_DIR", dir.path());
 
         watch_metrics(MetricsWatchArgs {
             format: "jsonl".to_string(),
@@ -1775,11 +1791,6 @@ TOTAL                             950.0M      2464K      2464K         0K      1
         })
         .unwrap_err();
         assert!(err.to_string().contains("Invalid --interval"));
-
-        match old_vicaya_dir {
-            Some(value) => std::env::set_var("VICAYA_DIR", value),
-            None => std::env::remove_var("VICAYA_DIR"),
-        }
     }
 
     #[test]
@@ -1787,8 +1798,7 @@ TOTAL                             950.0M      2464K      2464K         0K      1
         let _lock = vicaya_core::paths::test_env_lock();
         let vicaya_dir = tempfile::tempdir().unwrap();
         let queries_dir = tempfile::tempdir().unwrap();
-        let old_vicaya_dir = std::env::var_os("VICAYA_DIR");
-        std::env::set_var("VICAYA_DIR", vicaya_dir.path());
+        let _vicaya_dir_guard = EnvVarGuard::set_path("VICAYA_DIR", vicaya_dir.path());
 
         let empty = queries_dir.path().join("empty.txt");
         std::fs::write(&empty, "\n# no queries\n").unwrap();
@@ -1815,10 +1825,5 @@ TOTAL                             950.0M      2464K      2464K         0K      1
         })
         .unwrap_err();
         assert!(err.to_string().contains("Daemon is not running"));
-
-        match old_vicaya_dir {
-            Some(value) => std::env::set_var("VICAYA_DIR", value),
-            None => std::env::remove_var("VICAYA_DIR"),
-        }
     }
 }

--- a/crates/vicaya-cli/src/metrics.rs
+++ b/crates/vicaya-cli/src/metrics.rs
@@ -1448,6 +1448,107 @@ fn format_us(us: u64) -> String {
 mod tests {
     use super::*;
 
+    fn build_info() -> BuildInfo {
+        BuildInfo {
+            version: "1.2.0".to_string(),
+            git_sha: "abc1234".to_string(),
+            timestamp: "2026-05-19T00:00:00Z".to_string(),
+            target: "aarch64-apple-darwin".to_string(),
+        }
+    }
+
+    fn file_snapshot(path: &str, exists: bool, size_bytes: u64) -> FileSnapshot {
+        FileSnapshot {
+            path: path.to_string(),
+            exists,
+            size_bytes,
+            modified_unix_ms: Some(1_700_000_000_000),
+        }
+    }
+
+    fn rich_snapshot() -> MetricsSnapshot {
+        let index = IndexSnapshot {
+            files: 100,
+            trigrams: 2_000,
+            arena_bytes: 10_000,
+            index_allocated_bytes: 20_000,
+            state_allocated_bytes: 30_000,
+            last_updated: 1_700_000_000,
+            reconciling: true,
+        };
+        let process = ProcessSnapshot {
+            pid: 42,
+            ps: PsSnapshot {
+                captured: true,
+                command: "ps -p 42 -o rss= -o etime=".to_string(),
+                ok: true,
+                error: None,
+                rss_bytes: Some(64 * 1024 * 1024),
+                etime: Some("00:01".to_string()),
+            },
+            vmmap: VmmapSnapshot {
+                captured: true,
+                command: "vmmap -summary 42".to_string(),
+                ok: true,
+                error: None,
+                physical_footprint_bytes: Some(128 * 1024 * 1024),
+                physical_footprint_peak_bytes: Some(256 * 1024 * 1024),
+                total: Some(VmmapTotals {
+                    virtual_bytes: 512 * 1024 * 1024,
+                    resident_bytes: 128 * 1024 * 1024,
+                    dirty_bytes: 64 * 1024 * 1024,
+                    swapped_bytes: 4 * 1024 * 1024,
+                    volatile_bytes: 0,
+                    nonvol_bytes: 0,
+                    empty_bytes: 0,
+                    region_count: 200,
+                }),
+                malloc_zone_total: Some(VmmapMallocTotals {
+                    virtual_bytes: 64 * 1024 * 1024,
+                    resident_bytes: 32 * 1024 * 1024,
+                    dirty_bytes: 32 * 1024 * 1024,
+                    swapped_bytes: 0,
+                    allocation_count: 10_000,
+                    allocated_bytes: 24 * 1024 * 1024,
+                    frag_bytes: 8 * 1024 * 1024,
+                    frag_pct: 25.0,
+                    region_count: 10,
+                }),
+            },
+        };
+        let derived = derive_metrics(Some(&index), Some(&process));
+
+        MetricsSnapshot {
+            schema_version: 1,
+            tick: Some(7),
+            captured_at_unix_ms: 1_700_000_000_000,
+            captured_at_rfc3339: "2026-05-19T00:00:00.000Z".to_string(),
+            client: ClientSnapshot {
+                build: build_info(),
+                cwd: Some("/tmp/repo".to_string()),
+                args: vec!["vicaya".to_string(), "metrics".to_string()],
+            },
+            daemon: DaemonSnapshot {
+                running: true,
+                pid: Some(42),
+                pid_file: "/tmp/vicaya/daemon.pid".to_string(),
+                socket_path: "/tmp/vicaya/daemon.sock".to_string(),
+                build: Some(build_info()),
+                connect_error: None,
+            },
+            index: Some(index),
+            disk: DiskSnapshot {
+                config_path: "/tmp/vicaya/config.toml".to_string(),
+                index_dir: "/tmp/vicaya/index".to_string(),
+                index_file: file_snapshot("/tmp/vicaya/index/index.bin", true, 99_000),
+                journal_file: file_snapshot("/tmp/vicaya/index/index.journal", true, 1_024),
+            },
+            process: Some(process),
+            derived,
+            notes: vec!["sample".to_string()],
+        }
+    }
+
     #[test]
     fn parses_vmmap_sizes() {
         assert_eq!(parse_vmmap_size_to_bytes("0K"), Some(0));
@@ -1526,5 +1627,198 @@ TOTAL                             950.0M      2464K      2464K         0K      1
         assert_eq!(parse_duration("2s"), Some(Duration::from_secs(2)));
         assert_eq!(parse_duration("3m"), Some(Duration::from_secs(180)));
         assert_eq!(parse_duration("5"), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn pretty_snapshot_covers_running_and_degraded_metrics_paths() {
+        let rich = rich_snapshot();
+        print_pretty_snapshot(&rich, true);
+        print_pretty_snapshot(&rich, false);
+
+        let degraded = MetricsSnapshot {
+            schema_version: 1,
+            tick: None,
+            captured_at_unix_ms: 1_700_000_000_000,
+            captured_at_rfc3339: "2026-05-19T00:00:00.000Z".to_string(),
+            client: ClientSnapshot {
+                build: build_info(),
+                cwd: None,
+                args: Vec::new(),
+            },
+            daemon: DaemonSnapshot {
+                running: false,
+                pid: None,
+                pid_file: "/tmp/vicaya/daemon.pid".to_string(),
+                socket_path: "/tmp/vicaya/daemon.sock".to_string(),
+                build: None,
+                connect_error: Some("Daemon not running".to_string()),
+            },
+            index: None,
+            disk: DiskSnapshot {
+                config_path: "/tmp/vicaya/config.toml".to_string(),
+                index_dir: "/tmp/vicaya/index".to_string(),
+                index_file: file_snapshot("/tmp/vicaya/index/index.bin", false, 0),
+                journal_file: file_snapshot("/tmp/vicaya/index/index.journal", false, 0),
+            },
+            process: None,
+            derived: DerivedSnapshot::default(),
+            notes: vec!["Daemon is not running".to_string()],
+        };
+
+        print_pretty_snapshot(&degraded, true);
+    }
+
+    #[test]
+    fn snapshot_collection_handles_absent_daemon_without_failing() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let old_vicaya_dir = std::env::var_os("VICAYA_DIR");
+        std::env::set_var("VICAYA_DIR", dir.path());
+
+        let ctx = build_snapshot_context().unwrap();
+        let snapshot = collect_snapshot(
+            SnapshotMode::OneShot {
+                include_vmmap: false,
+            },
+            &ctx,
+        )
+        .unwrap();
+
+        assert!(!snapshot.daemon.running);
+        assert!(snapshot.index.is_none());
+        assert!(snapshot
+            .notes
+            .iter()
+            .any(|note| note.contains("Daemon is not running")));
+
+        match old_vicaya_dir {
+            Some(value) => std::env::set_var("VICAYA_DIR", value),
+            None => std::env::remove_var("VICAYA_DIR"),
+        }
+    }
+
+    #[test]
+    fn formatting_and_summary_helpers_handle_edges() {
+        assert_eq!(fit_value_right("abc", 6), "   abc");
+        assert_eq!(fit_value_right("abcdef", 4), "...f");
+        assert_eq!(fit_value_right("abcdef", 3), "...");
+        assert_eq!(fit_value_right("abc", 0), "");
+        assert_eq!(format_bytes_mb(512 * 1024), "0.5 MB");
+        assert_eq!(format_bytes_mb(2 * 1024 * 1024 * 1024), "2.00 GB");
+        assert_eq!(format_us(999), "999µs");
+        assert_eq!(format_us(12_300), "12.3ms");
+        assert_eq!(format_us(2_500_000), "2.5s");
+
+        let samples = vec![10, 20, 30, 40, 50];
+        let summary = summarize_latencies(&samples, 5, 1, Duration::from_millis(250));
+        assert_eq!(summary.ok_runs, 5);
+        assert_eq!(summary.error_runs, 1);
+        assert_eq!(summary.min_us, 10);
+        assert_eq!(summary.p50_us, 30);
+        assert_eq!(summary.max_us, 50);
+        assert_eq!(summary.mean_us, 30);
+        assert_eq!(summary.total_time_ms, 250);
+        assert!(summary.qps > 0.0);
+
+        let empty = summarize_latencies(&[], 0, 3, Duration::ZERO);
+        assert_eq!(empty.min_us, 0);
+        assert_eq!(empty.p99_us, 0);
+        assert_eq!(empty.qps, 0.0);
+        assert_eq!(percentile(&samples, -10.0), 10);
+        assert_eq!(percentile(&samples, 110.0), 50);
+    }
+
+    #[test]
+    fn load_queries_ignores_comments_and_blank_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("queries.txt");
+        std::fs::write(&path, "\n# comment\nCargo.toml\n\nREADME.md\n").unwrap();
+
+        assert_eq!(
+            load_queries(&path).unwrap(),
+            vec!["Cargo.toml".to_string(), "README.md".to_string()]
+        );
+    }
+
+    #[test]
+    fn process_collectors_return_structured_failures_for_missing_processes() {
+        let ps = collect_ps(-1);
+        assert!(ps.captured);
+        assert!(!ps.ok);
+        assert!(ps.error.is_some());
+
+        let process = collect_process(-1, false);
+        assert_eq!(process.pid, -1);
+        assert!(!process.vmmap.captured);
+    }
+
+    #[test]
+    fn watch_metrics_supports_bounded_jsonl_and_rejects_bad_interval() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let old_vicaya_dir = std::env::var_os("VICAYA_DIR");
+        std::env::set_var("VICAYA_DIR", dir.path());
+
+        watch_metrics(MetricsWatchArgs {
+            format: "jsonl".to_string(),
+            interval: "1ms".to_string(),
+            count: Some(1),
+            vmmap_every: 0,
+        })
+        .unwrap();
+
+        let err = watch_metrics(MetricsWatchArgs {
+            format: "jsonl".to_string(),
+            interval: "nope".to_string(),
+            count: Some(1),
+            vmmap_every: 0,
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("Invalid --interval"));
+
+        match old_vicaya_dir {
+            Some(value) => std::env::set_var("VICAYA_DIR", value),
+            None => std::env::remove_var("VICAYA_DIR"),
+        }
+    }
+
+    #[test]
+    fn bench_metrics_reports_empty_queries_and_absent_daemon_cleanly() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let vicaya_dir = tempfile::tempdir().unwrap();
+        let queries_dir = tempfile::tempdir().unwrap();
+        let old_vicaya_dir = std::env::var_os("VICAYA_DIR");
+        std::env::set_var("VICAYA_DIR", vicaya_dir.path());
+
+        let empty = queries_dir.path().join("empty.txt");
+        std::fs::write(&empty, "\n# no queries\n").unwrap();
+        let err = bench_metrics(MetricsBenchArgs {
+            format: "json".to_string(),
+            queries: empty,
+            runs: 1,
+            warmup: 0,
+            limit: 5,
+            vmmap_before_after: false,
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("No queries found"));
+
+        let queries = queries_dir.path().join("queries.txt");
+        std::fs::write(&queries, "Cargo.toml\n").unwrap();
+        let err = bench_metrics(MetricsBenchArgs {
+            format: "pretty".to_string(),
+            queries,
+            runs: 1,
+            warmup: 0,
+            limit: 5,
+            vmmap_before_after: true,
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("Daemon is not running"));
+
+        match old_vicaya_dir {
+            Some(value) => std::env::set_var("VICAYA_DIR", value),
+            None => std::env::remove_var("VICAYA_DIR"),
+        }
     }
 }

--- a/crates/vicaya-cli/tests/cli_operational_flows.rs
+++ b/crates/vicaya-cli/tests/cli_operational_flows.rs
@@ -1,0 +1,298 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use vicaya_core::config::PerformanceConfig;
+use vicaya_core::Config;
+
+struct DaemonGuard {
+    vicaya_bin: PathBuf,
+    vicaya_dir: PathBuf,
+    daemon_bin: PathBuf,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = Command::new(&self.vicaya_bin)
+            .env("VICAYA_DIR", &self.vicaya_dir)
+            .env("VICAYA_DAEMON_BIN", &self.daemon_bin)
+            .args(["daemon", "stop"])
+            .output();
+    }
+}
+
+fn daemon_bin_for(vicaya_bin: &Path) -> PathBuf {
+    vicaya_bin
+        .parent()
+        .unwrap()
+        .join(format!("vicaya-daemon{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn ensure_workspace_daemon_built(vicaya_bin: &Path) -> PathBuf {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let daemon_bin = daemon_bin_for(vicaya_bin);
+
+    let status = Command::new("cargo")
+        .current_dir(&workspace_root)
+        .args(["build", "-p", "vicaya-daemon"])
+        .status()
+        .unwrap();
+    assert!(status.success(), "failed to build vicaya-daemon");
+    assert!(
+        daemon_bin.exists(),
+        "missing daemon binary at {}",
+        daemon_bin.display()
+    );
+    daemon_bin
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+fn write_config(vicaya_dir: &Path, root: &Path) {
+    let config = Config {
+        index_roots: vec![root.to_path_buf()],
+        exclusions: vec!["target".to_string(), "*.profraw".to_string()],
+        index_path: vicaya_dir.join("index"),
+        max_memory_mb: 64,
+        performance: PerformanceConfig {
+            scanner_threads: 2,
+            reconcile_hour: 3,
+        },
+    };
+    std::fs::create_dir_all(vicaya_dir).unwrap();
+    config.save(&vicaya_dir.join("config.toml")).unwrap();
+}
+
+fn run_vicaya(vicaya_bin: &Path, vicaya_dir: &Path, daemon_bin: &Path, args: &[&str]) -> String {
+    let output = Command::new(vicaya_bin)
+        .env("VICAYA_DIR", vicaya_dir)
+        .env("VICAYA_DAEMON_BIN", daemon_bin)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "vicaya {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn wait_for_status_json(
+    vicaya_bin: &Path,
+    vicaya_dir: &Path,
+    daemon_bin: &Path,
+) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let output = Command::new(vicaya_bin)
+            .env("VICAYA_DIR", vicaya_dir)
+            .env("VICAYA_DAEMON_BIN", daemon_bin)
+            .args(["status", "--format=json"])
+            .output()
+            .unwrap();
+        if output.status.success() {
+            if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
+                return json;
+            }
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for status json: stdout={} stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn init_version_and_no_command_are_stable() {
+    let vicaya_bin = PathBuf::from(env!("CARGO_BIN_EXE_vicaya"));
+    let daemon_bin = daemon_bin_for(&vicaya_bin);
+    let vicaya_dir = TempDir::new().unwrap();
+
+    let version = run_vicaya(&vicaya_bin, vicaya_dir.path(), &daemon_bin, &["--version"]);
+    assert!(version.contains("vicaya"));
+
+    let no_command = run_vicaya(&vicaya_bin, vicaya_dir.path(), &daemon_bin, &[]);
+    assert!(no_command.contains("Use --help"));
+
+    let init = run_vicaya(&vicaya_bin, vicaya_dir.path(), &daemon_bin, &["init"]);
+    assert!(init.contains("Configuration initialized successfully"));
+    assert!(vicaya_dir.path().join("config.toml").exists());
+
+    let repeat = run_vicaya(&vicaya_bin, vicaya_dir.path(), &daemon_bin, &["init"]);
+    assert!(repeat.contains("Config already exists"));
+
+    let forced = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["init", "--force"],
+    );
+    assert!(forced.contains("Configuration initialized successfully"));
+}
+
+#[test]
+fn daemon_backed_status_metrics_rebuild_and_search_formats_work_together() {
+    let vicaya_bin = PathBuf::from(env!("CARGO_BIN_EXE_vicaya"));
+    let daemon_bin = ensure_workspace_daemon_built(&vicaya_bin);
+    let vicaya_dir = TempDir::new().unwrap();
+    let corpus = TempDir::new().unwrap();
+
+    let repo = corpus.path().join("repo");
+    let readme = repo.join("README.md");
+    let cargo = repo.join("Cargo.toml");
+    let target = repo.join("target").join("ignored.txt");
+    write_file(&readme, "# demo\n");
+    write_file(&cargo, "[package]\nname = \"demo\"\n");
+    write_file(&target, "ignored\n");
+    write_config(vicaya_dir.path(), corpus.path());
+
+    let status_before = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["daemon", "status"],
+    );
+    assert!(status_before.contains("Daemon is not running"));
+
+    let dry_run = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["rebuild", "--dry-run"],
+    );
+    assert!(dry_run.contains("Dry run: would index"));
+
+    let rebuild = run_vicaya(&vicaya_bin, vicaya_dir.path(), &daemon_bin, &["rebuild"]);
+    assert!(rebuild.contains("Index rebuilt:"));
+
+    let _guard = DaemonGuard {
+        vicaya_bin: vicaya_bin.clone(),
+        vicaya_dir: vicaya_dir.path().to_path_buf(),
+        daemon_bin: daemon_bin.clone(),
+    };
+
+    let table = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["search", "Cargo.toml", "--limit=5"],
+    );
+    assert!(table.contains("RANK"));
+    assert!(table.contains("Cargo.toml"));
+
+    let plain = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["search", "README", "--format=plain", "--limit=5"],
+    );
+    assert!(plain.lines().any(|line| line.ends_with("README.md")));
+
+    let json = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["search", "Cargo.toml", "--format=json", "--limit=5"],
+    );
+    let results: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        results
+            .first()
+            .and_then(|v| v.get("path"))
+            .and_then(|p| p.as_str()),
+        Some(cargo.to_string_lossy().as_ref())
+    );
+
+    let status_json = wait_for_status_json(&vicaya_bin, vicaya_dir.path(), &daemon_bin);
+    assert_eq!(status_json["daemon"]["running"], true);
+    assert!(status_json["index"]["files"].as_u64().unwrap() >= 2);
+
+    let pretty_status = run_vicaya(&vicaya_bin, vicaya_dir.path(), &daemon_bin, &["status"]);
+    assert!(pretty_status.contains("Vicaya"));
+    assert!(pretty_status.contains("Index Statistics"));
+
+    let daemon_status = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["daemon", "status"],
+    );
+    assert!(daemon_status.contains("Daemon is running"));
+    assert!(daemon_status.contains("Index Status"));
+
+    let metrics_json = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["metrics", "--format=json", "--no-vmmap"],
+    );
+    let metrics: serde_json::Value = serde_json::from_str(&metrics_json).unwrap();
+    assert_eq!(metrics["schema_version"], 1);
+    assert_eq!(metrics["daemon"]["running"], true);
+
+    let metrics_pretty = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &["metrics", "--no-vmmap"],
+    );
+    assert!(metrics_pretty.contains("Vicaya"));
+
+    let queries = corpus.path().join("bench-queries.txt");
+    std::fs::write(&queries, "Cargo.toml\nREADME\n").unwrap();
+
+    let bench_json = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &[
+            "metrics",
+            "bench",
+            "--format=json",
+            "--queries",
+            queries.to_string_lossy().as_ref(),
+            "--runs=3",
+            "--warmup=1",
+            "--limit=5",
+        ],
+    );
+    let bench: serde_json::Value = serde_json::from_str(&bench_json).unwrap();
+    assert_eq!(bench["schema_version"], 1);
+    assert_eq!(bench["params"]["query_count"], 2);
+    assert_eq!(bench["summary"]["ok_runs"], 3);
+
+    let bench_pretty = run_vicaya(
+        &vicaya_bin,
+        vicaya_dir.path(),
+        &daemon_bin,
+        &[
+            "metrics",
+            "bench",
+            "--queries",
+            queries.to_string_lossy().as_ref(),
+            "--runs=2",
+            "--warmup=1",
+            "--limit=5",
+        ],
+    );
+    assert!(bench_pretty.contains("Vicaya"));
+    assert!(bench_pretty.contains("Runs: 2"));
+}

--- a/crates/vicaya-daemon/src/ipc_server.rs
+++ b/crates/vicaya-daemon/src/ipc_server.rs
@@ -1054,4 +1054,179 @@ mod tests {
             "overwritten destination should not survive in inode map"
         );
     }
+
+    #[test]
+    fn apply_update_create_modify_delete_and_exclusions_keep_maps_consistent() {
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let mut state = build_state(root.path(), vicaya_dir.path());
+
+        let file = root.path().join("note.txt");
+        std::fs::write(&file, "one").unwrap();
+        state.apply_update(IndexUpdate::Create {
+            path: file.to_string_lossy().to_string(),
+        });
+        let file_id = state.get_file_id_for_path(&file.to_string_lossy()).unwrap();
+        assert!(state.indexed_file_count() >= 1);
+
+        std::fs::write(&file, "updated").unwrap();
+        state.apply_update(IndexUpdate::Modify {
+            path: file.to_string_lossy().to_string(),
+        });
+        let meta = state.snapshot.file_table.get(file_id).unwrap();
+        assert_eq!(meta.size, 7);
+
+        state.config.exclusions.push("target".to_string());
+        let excluded = root.path().join("target").join("ignored.txt");
+        std::fs::create_dir_all(excluded.parent().unwrap()).unwrap();
+        std::fs::write(&excluded, "ignored").unwrap();
+        state.apply_update(IndexUpdate::Create {
+            path: excluded.to_string_lossy().to_string(),
+        });
+        assert!(state
+            .get_file_id_for_path(&excluded.to_string_lossy())
+            .is_none());
+
+        state.apply_update(IndexUpdate::Delete {
+            path: file.to_string_lossy().to_string(),
+        });
+        assert!(state
+            .get_file_id_for_path(&file.to_string_lossy())
+            .is_none());
+        assert_eq!(state.snapshot.file_table.get(file_id).unwrap().path_len, 0);
+    }
+
+    #[test]
+    fn move_unknown_source_upserts_destination_and_excluded_move_tombstones() {
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let mut state = build_state(root.path(), vicaya_dir.path());
+
+        let unknown = root.path().join("missing.txt");
+        let created = root.path().join("created.txt");
+        std::fs::write(&created, "created").unwrap();
+        state.apply_update(IndexUpdate::Move {
+            from: unknown.to_string_lossy().to_string(),
+            to: created.to_string_lossy().to_string(),
+        });
+        let created_id = state
+            .get_file_id_for_path(&created.to_string_lossy())
+            .unwrap();
+
+        state.config.exclusions.push("target".to_string());
+        let excluded = root.path().join("target").join("created.txt");
+        std::fs::create_dir_all(excluded.parent().unwrap()).unwrap();
+        std::fs::rename(&created, &excluded).unwrap();
+        state.apply_update(IndexUpdate::Move {
+            from: created.to_string_lossy().to_string(),
+            to: excluded.to_string_lossy().to_string(),
+        });
+
+        assert!(state
+            .get_file_id_for_path(&created.to_string_lossy())
+            .is_none());
+        assert!(state
+            .get_file_id_for_path(&excluded.to_string_lossy())
+            .is_none());
+        assert_eq!(
+            state.snapshot.file_table.get(created_id).unwrap().path_len,
+            0
+        );
+    }
+
+    #[test]
+    fn journal_replay_skips_bad_lines_and_truncate_resets_file() {
+        let dir = tempdir().unwrap();
+        let journal = dir.path().join("index.journal");
+        let first = IndexUpdate::Create {
+            path: "/tmp/one.txt".to_string(),
+        };
+        let second = IndexUpdate::Delete {
+            path: "/tmp/two.txt".to_string(),
+        };
+        let first_line = serde_json::to_string(&first).unwrap();
+        let offset = first_line.len() as u64 + 1;
+        std::fs::write(
+            &journal,
+            format!(
+                "{first_line}\nnot-json\n{}\n\n",
+                serde_json::to_string(&second).unwrap()
+            ),
+        )
+        .unwrap();
+
+        let mut applied = Vec::new();
+        let count = apply_journal_from_offset(&journal, offset, |update| applied.push(update));
+        assert_eq!(count, 1);
+        assert!(matches!(applied[0], IndexUpdate::Delete { .. }));
+
+        truncate_journal(&journal).unwrap();
+        assert_eq!(std::fs::metadata(&journal).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn ipc_server_handle_request_covers_status_search_rebuild_and_shutdown() {
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cargo = root.path().join("Cargo.toml");
+        std::fs::write(&cargo, "[package]\n").unwrap();
+
+        let state = Arc::new(RwLock::new(build_state(root.path(), vicaya_dir.path())));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let journal_lock = Arc::new(Mutex::new(()));
+        let rebuild_lock = Arc::new(Mutex::new(()));
+        let socket = vicaya_dir.path().join("daemon.sock");
+        let server =
+            IpcServer::new(&socket, state, shutdown.clone(), journal_lock, rebuild_lock).unwrap();
+
+        match server.handle_request(Request::Status) {
+            Response::Status {
+                indexed_files,
+                trigram_count,
+                ..
+            } => {
+                assert!(indexed_files >= 1);
+                assert!(trigram_count > 0);
+            }
+            other => panic!("unexpected status response: {other:?}"),
+        }
+
+        match server.handle_request(Request::Search {
+            query: "Cargo".to_string(),
+            limit: 10,
+            scope: Some(root.path().to_string_lossy().to_string()),
+            filter_scope: Some(root.path().to_string_lossy().to_string()),
+            recent_if_empty: false,
+        }) {
+            Response::SearchResults { results } => {
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].path, cargo.to_string_lossy());
+            }
+            other => panic!("unexpected search response: {other:?}"),
+        }
+
+        match server.handle_request(Request::Search {
+            query: String::new(),
+            limit: 10,
+            scope: None,
+            filter_scope: Some(root.path().to_string_lossy().to_string()),
+            recent_if_empty: true,
+        }) {
+            Response::SearchResults { results } => {
+                assert!(results.iter().any(|r| r.path == cargo.to_string_lossy()))
+            }
+            other => panic!("unexpected recent response: {other:?}"),
+        }
+
+        match server.handle_request(Request::Rebuild { dry_run: true }) {
+            Response::RebuildComplete { files_indexed } => assert!(files_indexed >= 1),
+            other => panic!("unexpected rebuild response: {other:?}"),
+        }
+
+        assert!(matches!(
+            server.handle_request(Request::Shutdown),
+            Response::Ok
+        ));
+        assert!(shutdown.load(Ordering::Relaxed));
+    }
 }

--- a/crates/vicaya-tui/src/app.rs
+++ b/crates/vicaya-tui/src/app.rs
@@ -1145,3 +1145,407 @@ fn render_search(f: &mut Frame, app: &mut AppState) {
 
     ui::footer::render(f, chunks[3], app);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{FocusTarget, StyledLine, StyledSegment, TextKind, TextStyle, ViewKind};
+    use ratatui::{backend::TestBackend, Terminal};
+    use vicaya_core::ipc::BuildInfo;
+    use vicaya_index::SearchResult;
+
+    fn search_result(path: &std::path::Path, name: &str, size: u64) -> SearchResult {
+        SearchResult {
+            path: path.to_string_lossy().to_string(),
+            name: name.to_string(),
+            score: 0.92,
+            size,
+            mtime: 1_700_000_000,
+        }
+    }
+
+    fn plain_line(text: &str) -> StyledLine {
+        vec![StyledSegment {
+            text: text.to_string(),
+            style: TextStyle::default(),
+        }]
+    }
+
+    fn meta_line(text: &str) -> StyledLine {
+        vec![StyledSegment {
+            text: text.to_string(),
+            style: TextStyle {
+                kind: TextKind::Meta,
+                ..Default::default()
+            },
+        }]
+    }
+
+    fn buffer_text(app: &mut AppState, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| ui_render(f, app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn apply_sample_status(app: &mut AppState) {
+        app.daemon_status = Some(crate::client::DaemonStatus {
+            build: BuildInfo {
+                version: "1.2.0".to_string(),
+                git_sha: "abc1234".to_string(),
+                timestamp: "2026-05-19T00:00:00Z".to_string(),
+                target: "aarch64-apple-darwin".to_string(),
+            },
+            indexed_files: 1_234_567,
+            trigram_count: 98_765,
+            arena_size: 4_096,
+            last_updated: 1_700_000_000,
+            reconciling: true,
+        });
+    }
+
+    #[test]
+    fn search_mode_keys_cover_query_focus_preview_and_selection_actions() {
+        let dir = tempfile::tempdir().unwrap();
+        let subdir = dir.path().join("src");
+        std::fs::create_dir_all(&subdir).unwrap();
+        let file = dir.path().join("README.md");
+        std::fs::write(&file, "readme").unwrap();
+
+        let mut app = AppState::new();
+        app.search.set_results(vec![
+            search_result(&subdir, "src", 0),
+            search_result(&file, "README.md", 6),
+        ]);
+        app.ui.viewport_height = 1;
+
+        handle_key_event(&mut app, KeyCode::Char('c'), KeyModifiers::NONE);
+        handle_key_event(&mut app, KeyCode::Char('a'), KeyModifiers::NONE);
+        handle_key_event(&mut app, KeyCode::Char('r'), KeyModifiers::NONE);
+        handle_key_event(&mut app, KeyCode::Left, KeyModifiers::NONE);
+        handle_key_event(&mut app, KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(app.search.query, "cr");
+
+        handle_key_event(&mut app, KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(app.search.focus, FocusTarget::Results);
+        handle_key_event(&mut app, KeyCode::Char('j'), KeyModifiers::NONE);
+        assert_eq!(app.search.selected_index, 1);
+        handle_key_event(&mut app, KeyCode::PageUp, KeyModifiers::NONE);
+        assert_eq!(app.search.selected_index, 0);
+        handle_key_event(&mut app, KeyCode::Char('G'), KeyModifiers::SHIFT);
+        assert_eq!(app.search.selected_index, 1);
+        handle_key_event(&mut app, KeyCode::Char('g'), KeyModifiers::NONE);
+        assert_eq!(app.search.selected_index, 0);
+
+        handle_key_event(&mut app, KeyCode::Right, KeyModifiers::NONE);
+        assert_eq!(app.ksetra.current(), Some(&subdir));
+        assert!(app.search.is_searching);
+        assert!(app.search.results.is_empty());
+
+        app.search
+            .set_results(vec![search_result(&file, "README.md", 6)]);
+        app.search.focus = FocusTarget::Results;
+        handle_key_event(&mut app, KeyCode::Char('p'), KeyModifiers::NONE);
+        assert_eq!(app.print_on_exit, Some(file.to_string_lossy().to_string()));
+        assert!(app.should_quit());
+    }
+
+    #[test]
+    fn global_search_keys_toggle_modes_and_preview_focus_safely() {
+        let mut app = AppState::new();
+        app.search.focus = FocusTarget::Results;
+
+        handle_key_event(&mut app, KeyCode::Char('?'), KeyModifiers::NONE);
+        assert_eq!(app.mode, AppMode::Help);
+        handle_key_event(&mut app, KeyCode::Esc, KeyModifiers::NONE);
+        assert_eq!(app.mode, AppMode::Search);
+
+        handle_key_event(&mut app, KeyCode::Char('t'), KeyModifiers::CONTROL);
+        assert_eq!(app.mode, AppMode::DrishtiSwitcher);
+        handle_key_event(&mut app, KeyCode::Esc, KeyModifiers::NONE);
+        assert_eq!(app.mode, AppMode::Search);
+
+        handle_key_event(&mut app, KeyCode::Char('p'), KeyModifiers::CONTROL);
+        assert_eq!(app.mode, AppMode::KriyaSuchi);
+        handle_key_event(&mut app, KeyCode::Char('p'), KeyModifiers::CONTROL);
+        assert_eq!(app.mode, AppMode::Search);
+
+        handle_key_event(&mut app, KeyCode::Tab, KeyModifiers::NONE);
+        assert_eq!(app.search.focus, FocusTarget::Preview);
+        handle_key_event(&mut app, KeyCode::Char('o'), KeyModifiers::CONTROL);
+        assert!(!app.preview.is_visible);
+        assert_eq!(app.search.focus, FocusTarget::Results);
+        handle_key_event(&mut app, KeyCode::BackTab, KeyModifiers::SHIFT);
+        assert_eq!(app.search.focus, FocusTarget::Input);
+    }
+
+    #[test]
+    fn drishti_switcher_selects_enabled_views_and_reports_disabled_views() {
+        let mut app = AppState::new();
+
+        app.toggle_drishti_switcher();
+        for ch in "sth".chars() {
+            handle_key_event(&mut app, KeyCode::Char(ch), KeyModifiers::NONE);
+        }
+        handle_key_event(&mut app, KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(app.view, ViewKind::Sthana);
+        assert_eq!(app.mode, AppMode::Search);
+
+        app.toggle_drishti_switcher();
+        handle_key_event(&mut app, KeyCode::Char('m'), KeyModifiers::NONE);
+        handle_key_event(&mut app, KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(app.view, ViewKind::Sthana);
+        assert_eq!(app.mode, AppMode::Search);
+        assert!(app
+            .error
+            .as_deref()
+            .is_some_and(|msg| msg.contains("coming soon")));
+    }
+
+    #[test]
+    fn kriya_actions_cover_safe_stateful_commands() {
+        let dir = tempfile::tempdir().unwrap();
+        let selected = dir.path().join("selected.txt");
+        std::fs::write(&selected, "selected").unwrap();
+
+        let mut app = AppState::new();
+        app.ksetra.push(dir.path().to_path_buf());
+        app.search
+            .set_results(vec![search_result(&selected, "selected.txt", 8)]);
+        app.preview.lines = vec![plain_line("needle"), plain_line("haystack")];
+        app.preview.search_query = "needle".to_string();
+
+        run_kriya_action(&mut app, crate::kriya::KriyaId::TogglePreview);
+        assert!(!app.preview.is_visible);
+        run_kriya_action(&mut app, crate::kriya::KriyaId::ToggleGrouping);
+        assert_eq!(app.ui.grouping.label(), "dir");
+        run_kriya_action(&mut app, crate::kriya::KriyaId::PopKsetra);
+        assert!(app.ksetra.is_global());
+        run_kriya_action(&mut app, crate::kriya::KriyaId::SetKsetra);
+        assert_eq!(app.mode, AppMode::KsetraInput);
+
+        app.mode = AppMode::Search;
+        run_kriya_action(&mut app, crate::kriya::KriyaId::TogglePreviewLineNumbers);
+        assert!(app.preview.show_line_numbers);
+        run_kriya_action(&mut app, crate::kriya::KriyaId::ClearPreviewSearch);
+        assert!(app.preview.search_query.is_empty());
+        app.search
+            .set_results(vec![search_result(&selected, "selected.txt", 8)]);
+        run_kriya_action(&mut app, crate::kriya::KriyaId::PrintPath);
+        assert_eq!(
+            app.print_on_exit,
+            Some(selected.to_string_lossy().to_string())
+        );
+        assert!(app.should_quit());
+    }
+
+    #[test]
+    fn ksetra_input_validates_completes_and_applies_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let alpha = dir.path().join("alpha");
+        let beta = dir.path().join("beta");
+        std::fs::create_dir_all(&alpha).unwrap();
+        std::fs::create_dir_all(&beta).unwrap();
+        std::fs::write(dir.path().join("alpha.txt"), "").unwrap();
+
+        let mut app = AppState::new();
+        app.toggle_ksetra_input();
+        for ch in dir.path().join("a").to_string_lossy().chars() {
+            handle_key_event(&mut app, KeyCode::Char(ch), KeyModifiers::NONE);
+        }
+        handle_key_event(&mut app, KeyCode::Tab, KeyModifiers::NONE);
+        assert_eq!(app.ksetra_input.completions.len(), 1);
+        handle_key_event(&mut app, KeyCode::Tab, KeyModifiers::NONE);
+        assert_eq!(app.ksetra_input.input, alpha.to_string_lossy());
+        assert!(app.ksetra_input.completions.is_empty());
+
+        handle_key_event(&mut app, KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(app.mode, AppMode::Search);
+        assert_eq!(app.ksetra.current(), Some(&alpha));
+
+        app.toggle_ksetra_input();
+        for ch in dir.path().join("missing").to_string_lossy().chars() {
+            handle_key_event(&mut app, KeyCode::Char(ch), KeyModifiers::NONE);
+        }
+        handle_key_event(&mut app, KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(app.ksetra_input.error.as_deref(), Some("Not a directory"));
+    }
+
+    #[test]
+    fn preview_search_and_scrolling_keep_matches_visible() {
+        let mut app = AppState::new();
+        app.search.focus = FocusTarget::Preview;
+        app.ui.preview_viewport_height = 3;
+        app.preview.lines = vec![
+            meta_line("meta"),
+            plain_line("alpha"),
+            plain_line("beta"),
+            plain_line("gamma needle"),
+            plain_line("delta"),
+            plain_line("needle again"),
+        ];
+        app.preview.content_line_numbers =
+            crate::state::compute_content_line_numbers(&app.preview.lines);
+
+        handle_key_event(&mut app, KeyCode::Char('/'), KeyModifiers::NONE);
+        assert_eq!(app.mode, AppMode::PreviewSearch);
+        for ch in "needle".chars() {
+            handle_key_event(&mut app, KeyCode::Char(ch), KeyModifiers::NONE);
+        }
+        handle_key_event(&mut app, KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(app.mode, AppMode::Search);
+        assert_eq!(app.preview.search_query, "needle");
+        assert!(app.preview.scroll > 0);
+
+        let first_scroll = app.preview.scroll;
+        handle_key_event(&mut app, KeyCode::Char('n'), KeyModifiers::NONE);
+        assert!(app.preview.scroll >= first_scroll);
+        handle_key_event(&mut app, KeyCode::Char('G'), KeyModifiers::SHIFT);
+        assert_eq!(app.preview.scroll, 3);
+        handle_key_event(&mut app, KeyCode::PageUp, KeyModifiers::NONE);
+        assert_eq!(app.preview.scroll, 0);
+        handle_key_event(&mut app, KeyCode::Char('l'), KeyModifiers::CONTROL);
+        assert!(app.preview.search_query.is_empty());
+    }
+
+    #[test]
+    fn trigger_search_parses_niyamas_and_scopes_worker_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = AppState::with_startup_scope(Some(dir.path().to_path_buf()));
+        app.search.set_query("main ext:rs type:file".to_string());
+        let (tx, rx) = mpsc::channel();
+        let mut search_id = 0;
+        let mut active_search_id = 0;
+        let mut last = std::time::Instant::now();
+
+        trigger_search(
+            &tx,
+            &mut app,
+            &mut search_id,
+            &mut active_search_id,
+            &mut last,
+        );
+
+        match rx.try_recv().unwrap() {
+            WorkerCommand::Search {
+                id,
+                query,
+                limit,
+                boost_scope,
+                filter_scope,
+                niyamas,
+                ..
+            } => {
+                assert_eq!(id, 1);
+                assert_eq!(query, "main");
+                assert_eq!(limit, 100);
+                assert_eq!(boost_scope.as_deref(), Some(dir.path()));
+                assert_eq!(filter_scope.as_deref(), Some(dir.path()));
+                assert_eq!(niyamas.len(), 2);
+            }
+            _ => panic!("expected search command"),
+        }
+        assert_eq!(search_id, 1);
+        assert_eq!(active_search_id, 1);
+        assert!(app.search.is_searching);
+    }
+
+    #[test]
+    fn render_search_and_overlays_expose_real_tui_surfaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("Cargo.toml");
+        std::fs::write(&file, "[package]\nname = \"demo\"\n").unwrap();
+        let mut app = AppState::with_startup_scope(Some(dir.path().to_path_buf()));
+        apply_sample_status(&mut app);
+        app.search.set_query("cargo".to_string());
+        app.search
+            .set_results(vec![search_result(&file, "Cargo.toml", 24)]);
+        app.preview.title = "Cargo.toml".to_string();
+        app.preview.path = Some(file.to_string_lossy().to_string());
+        app.preview.lines = vec![
+            meta_line(file.to_string_lossy().as_ref()),
+            plain_line("name = demo"),
+        ];
+        app.preview.content_line_numbers =
+            crate::state::compute_content_line_numbers(&app.preview.lines);
+
+        let screen = buffer_text(&mut app, 120, 30);
+        assert!(screen.contains("vicaya"));
+        assert!(screen.contains("prashna: cargo"));
+        assert!(screen.contains("Cargo.toml"));
+        assert!(screen.contains("purvadarshana"));
+
+        app.mode = AppMode::Help;
+        assert!(buffer_text(&mut app, 100, 28).contains("Help"));
+
+        app.mode = AppMode::DrishtiSwitcher;
+        app.ui.drishti_switcher.push_filter_char('s');
+        assert!(buffer_text(&mut app, 100, 28).contains("Sthana"));
+
+        app.mode = AppMode::KriyaSuchi;
+        app.ui.kriya_suchi.push_filter_char('p');
+        let kriya = buffer_text(&mut app, 100, 28);
+        assert!(kriya.contains("Print path") || kriya.contains("purvadarshana"));
+
+        app.mode = AppMode::PreviewSearch;
+        app.preview.start_search();
+        app.preview.insert_search_char('d');
+        assert!(buffer_text(&mut app, 100, 28).contains("preview"));
+
+        app.mode = AppMode::KsetraInput;
+        app.ksetra_input.input = dir.path().to_string_lossy().to_string();
+        app.ksetra_input.cursor = app.ksetra_input.input.len();
+        app.ksetra_input
+            .set_completions(vec![dir.path().to_string_lossy().to_string()]);
+        assert!(buffer_text(&mut app, 100, 28).contains("ksetra"));
+
+        app.mode = AppMode::Confirm(crate::state::Action::Quit);
+        assert!(buffer_text(&mut app, 100, 28).contains("sure"));
+    }
+
+    #[test]
+    fn result_rendering_covers_grouping_scrolling_and_hidden_preview() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let tests = dir.path().join("tests");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&tests).unwrap();
+        let main_rs = src.join("main.rs");
+        let lib_rs = src.join("lib.rs");
+        let smoke_md = tests.join("smoke.md");
+        std::fs::write(&main_rs, "fn main() {}\n").unwrap();
+        std::fs::write(&lib_rs, "pub fn lib() {}\n").unwrap();
+        std::fs::write(&smoke_md, "# smoke\n").unwrap();
+
+        let mut app = AppState::new();
+        app.preview.is_visible = false;
+        app.search.set_query("src ext:rs".to_string());
+        app.search.set_results(vec![
+            search_result(&main_rs, "main.rs", 12),
+            search_result(&lib_rs, "lib.rs", 14),
+            search_result(&smoke_md, "smoke.md", 8),
+        ]);
+        app.search.focus = FocusTarget::Results;
+        app.search.selected_index = 2;
+        app.ui.viewport_height = 2;
+        app.ui.grouping = crate::state::GroupingMode::Directory;
+
+        let directory_screen = buffer_text(&mut app, 90, 16);
+        assert!(directory_screen.contains("src"));
+        assert!(directory_screen.contains("tests"));
+
+        app.ui.grouping = crate::state::GroupingMode::Extension;
+        app.ui.scroll_offset = 0;
+        let extension_screen = buffer_text(&mut app, 90, 16);
+        assert!(extension_screen.contains(".rs"));
+        assert!(extension_screen.contains(".md"));
+        assert!(extension_screen.contains("varga:ext"));
+    }
+}

--- a/crates/vicaya-tui/src/client/mod.rs
+++ b/crates/vicaya-tui/src/client/mod.rs
@@ -174,3 +174,150 @@ pub struct DaemonStatus {
     pub last_updated: i64,
     pub reconciling: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use vicaya_core::ipc::BuildInfo;
+
+    fn response_server(
+        dir: &std::path::Path,
+        response: Response,
+    ) -> std::thread::JoinHandle<Request> {
+        let socket = dir.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let line = vicaya_core::ipc::read_message(&mut reader)
+                .unwrap()
+                .unwrap();
+            let request = Request::from_json(&line).unwrap();
+            let mut json = response.to_json().unwrap();
+            json.push('\n');
+            stream.write_all(json.as_bytes()).unwrap();
+            request
+        })
+    }
+
+    fn build_info() -> BuildInfo {
+        BuildInfo {
+            version: "1.2.0".to_string(),
+            git_sha: "abc1234".to_string(),
+            timestamp: "2026-05-19T00:00:00Z".to_string(),
+            target: "aarch64-apple-darwin".to_string(),
+        }
+    }
+
+    #[test]
+    fn search_serializes_scope_and_maps_results() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", dir.path());
+        let response = Response::SearchResults {
+            results: vec![vicaya_core::ipc::SearchResult {
+                path: "/tmp/repo/Cargo.toml".to_string(),
+                name: "Cargo.toml".to_string(),
+                score: 0.9,
+                size: 123,
+                mtime: 1_700_000_000,
+            }],
+        };
+        let handle = response_server(dir.path(), response);
+
+        let mut client = IpcClient::new();
+        assert!(client.is_connected());
+        let results = client
+            .search(
+                "Cargo",
+                5,
+                Some(std::path::Path::new("/tmp/repo")),
+                Some(std::path::Path::new("/tmp/repo/src")),
+                false,
+            )
+            .unwrap();
+
+        let request = handle.join().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Cargo.toml");
+        match request {
+            Request::Search {
+                query,
+                limit,
+                scope,
+                filter_scope,
+                recent_if_empty,
+            } => {
+                assert_eq!(query, "Cargo");
+                assert_eq!(limit, 5);
+                assert_eq!(scope.as_deref(), Some("/tmp/repo"));
+                assert_eq!(filter_scope.as_deref(), Some("/tmp/repo/src"));
+                assert!(!recent_if_empty);
+            }
+            other => panic!("unexpected request: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_non_recent_search_returns_without_ipc() {
+        let mut client = IpcClient { stream: None };
+        let results = client.search("", 10, None, None, false).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn status_and_rebuild_map_daemon_responses() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", dir.path());
+        let status_response = Response::Status {
+            pid: 99,
+            build: build_info(),
+            indexed_files: 42,
+            trigram_count: 777,
+            arena_size: 4096,
+            index_allocated_bytes: 8192,
+            state_allocated_bytes: 16384,
+            last_updated: 1_700_000_000,
+            reconciling: true,
+        };
+        let handle = response_server(dir.path(), status_response);
+        let mut client = IpcClient::new();
+        let status = client.status().unwrap();
+        let request = handle.join().unwrap();
+        assert!(matches!(request, Request::Status));
+        assert_eq!(status.indexed_files, 42);
+        assert_eq!(status.trigram_count, 777);
+        assert!(status.reconciling);
+
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", dir.path());
+        let handle = response_server(dir.path(), Response::RebuildComplete { files_indexed: 12 });
+        let mut client = IpcClient::new();
+        assert_eq!(client.rebuild(true).unwrap(), 12);
+        assert!(matches!(
+            handle.join().unwrap(),
+            Request::Rebuild { dry_run: true }
+        ));
+    }
+
+    #[test]
+    fn daemon_error_responses_become_client_errors() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", dir.path());
+        let handle = response_server(
+            dir.path(),
+            Response::Error {
+                message: "boom".to_string(),
+            },
+        );
+        let mut client = IpcClient::new();
+        let err = client.search("x", 1, None, None, false).unwrap_err();
+        assert!(err.to_string().contains("boom"));
+        assert!(matches!(handle.join().unwrap(), Request::Search { .. }));
+    }
+}

--- a/crates/vicaya-tui/src/state/mod.rs
+++ b/crates/vicaya-tui/src/state/mod.rs
@@ -1629,4 +1629,137 @@ mod tests {
         assert_eq!(preview.search_input, "a");
         assert_eq!(preview.search_cursor, 0);
     }
+
+    #[test]
+    fn ui_scroll_keeps_selection_visible_and_clamped() {
+        let mut ui = UiState::new();
+        ui.viewport_height = 3;
+
+        ui.update_scroll(0, 10);
+        assert_eq!(ui.scroll_offset, 0);
+        ui.update_scroll(4, 10);
+        assert_eq!(ui.scroll_offset, 2);
+        ui.update_scroll(1, 10);
+        assert_eq!(ui.scroll_offset, 1);
+        ui.update_scroll(99, 5);
+        assert_eq!(ui.scroll_offset, 2);
+    }
+
+    #[test]
+    fn grouping_and_view_metadata_are_stable() {
+        assert_eq!(GroupingMode::None.label(), "none");
+        assert_eq!(GroupingMode::None.next(), GroupingMode::Directory);
+        assert_eq!(GroupingMode::Directory.next(), GroupingMode::Extension);
+        assert_eq!(GroupingMode::Extension.next(), GroupingMode::None);
+
+        let labels: Vec<&str> = ViewKind::ALL.iter().map(|v| v.label()).collect();
+        assert!(labels.contains(&"Patra"));
+        assert!(labels.contains(&"Sthana"));
+        assert!(labels.contains(&"Ankita"));
+        assert_eq!(ViewKind::Patra.english_hint(), "Files");
+        assert!(ViewKind::Patra.is_enabled());
+        assert!(ViewKind::Sthana.is_enabled());
+        assert!(!ViewKind::Smriti.is_enabled());
+    }
+
+    #[test]
+    fn switcher_states_filter_reset_and_wrap_selection() {
+        let mut drishti = DrishtiSwitcherState::new();
+        drishti.push_filter_char('d');
+        assert!(drishti.matching_views().contains(&ViewKind::Sthana));
+        drishti.select_previous();
+        assert!(drishti.selected_view().is_some());
+        drishti.pop_filter_char();
+        assert_eq!(drishti.filter_query(), "");
+        drishti.reset();
+        assert_eq!(drishti.selected_index, 0);
+
+        let mut kriya = KriyaSuchiState::new();
+        kriya.select_previous(3);
+        assert_eq!(kriya.selected_index, 2);
+        kriya.select_next(3);
+        assert_eq!(kriya.selected_index, 0);
+        kriya.push_filter_char('p');
+        assert_eq!(kriya.filter_query(), "p");
+        kriya.pop_filter_char();
+        kriya.select_next(0);
+        assert_eq!(kriya.selected_index, 0);
+        kriya.reset();
+        assert_eq!(kriya.filter_query(), "");
+    }
+
+    #[test]
+    fn ksetra_input_cursor_completion_and_error_state_are_consistent() {
+        let mut input = KsetraInputState::new();
+        input.push_char('a');
+        input.push_char('é');
+        input.push_char('b');
+        assert_eq!(input.input, "aéb");
+
+        input.move_cursor_left();
+        input.delete_char();
+        assert_eq!(input.input, "aé");
+        input.error = Some("old".to_string());
+        input.pop_char();
+        assert_eq!(input.input, "a");
+        assert!(input.error.is_none());
+        input.move_cursor_start();
+        input.push_char('z');
+        assert_eq!(input.input, "za");
+        input.move_cursor_end();
+        assert_eq!(input.cursor, input.input.len());
+
+        input.set_completions(vec![
+            "/tmp/a".to_string(),
+            "/tmp/b".to_string(),
+            "/tmp/c".to_string(),
+        ]);
+        input.select_previous_completion();
+        assert_eq!(input.selected_completion, 2);
+        input.select_next_completion();
+        assert_eq!(input.selected_completion, 0);
+        input.select_next_completion();
+        input.apply_completion();
+        assert_eq!(input.input, "/tmp/b");
+        assert!(input.completions.is_empty());
+    }
+
+    #[test]
+    fn preview_state_clear_toggle_and_search_lifecycle() {
+        let mut preview = PreviewState::new();
+        preview.path = Some("/tmp/file.rs".to_string());
+        preview.title = "file.rs".to_string();
+        preview.lines = vec![vec![StyledSegment {
+            text: "needle".to_string(),
+            style: TextStyle::default(),
+        }]];
+        preview.content_line_numbers = vec![Some(1)];
+        preview.scroll = 2;
+        preview.truncated = true;
+        preview.is_loading = true;
+        preview.toggle();
+        assert!(!preview.is_visible);
+        preview.toggle_line_numbers();
+        assert!(preview.show_line_numbers);
+
+        preview.search_query = "old".to_string();
+        preview.start_search();
+        assert_eq!(preview.search_input, "old");
+        preview.insert_search_char('x');
+        preview.cancel_search();
+        assert_eq!(preview.search_input, "old");
+        preview.search_input = "  new  ".to_string();
+        preview.search_cursor = preview.search_input.len();
+        preview.apply_search();
+        assert_eq!(preview.search_query, "new");
+        preview.clear_search();
+        assert!(preview.search_query.is_empty());
+
+        preview.clear();
+        assert!(preview.path.is_none());
+        assert!(preview.lines.is_empty());
+        assert_eq!(preview.scroll, 0);
+        assert!(!preview.is_loading);
+        assert!(!preview.truncated);
+    }
 }

--- a/crates/vicaya-tui/src/worker.rs
+++ b/crates/vicaya-tui/src/worker.rs
@@ -544,7 +544,29 @@ fn syntect_style_to_text_style(style: syntect::highlighting::Style) -> TextStyle
 mod tests {
     use super::*;
     use crate::state::{CmpOp, CmpU64};
+    use std::io::{BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use tempfile::tempdir;
+    use vicaya_core::ipc::{BuildInfo, Request, Response};
+
+    fn result(path: &std::path::Path, name: &str, size: u64, mtime: i64) -> SearchResult {
+        SearchResult {
+            path: path.to_string_lossy().to_string(),
+            name: name.to_string(),
+            score: 1.0,
+            size,
+            mtime,
+        }
+    }
+
+    fn test_syntaxes_and_theme() -> (SyntaxSet, ThemeSet) {
+        (
+            SyntaxSet::load_defaults_newlines(),
+            ThemeSet::load_defaults(),
+        )
+    }
 
     #[test]
     fn matches_filters_applies_scope_and_size() {
@@ -628,5 +650,335 @@ mod tests {
             Some(dir.path()),
             &ext_rs
         ));
+    }
+
+    #[test]
+    fn matches_filters_rejects_out_of_scope_path_filters_and_mtime() {
+        let dir = tempdir().unwrap();
+        let in_scope = dir.path().join("src").join("main.rs");
+        let out_scope = dir.path().join("target").join("main.rs");
+        std::fs::create_dir_all(in_scope.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(out_scope.parent().unwrap()).unwrap();
+        std::fs::write(&in_scope, "fn main() {}\n").unwrap();
+        std::fs::write(&out_scope, "fn main() {}\n").unwrap();
+
+        let niyamas = vec![
+            Niyama::Path {
+                needle: "src".to_string(),
+                raw: "path:src".to_string(),
+            },
+            Niyama::Mtime {
+                cmp: crate::state::CmpI64 {
+                    op: CmpOp::Gte,
+                    value: 100,
+                },
+                raw: "mtime:>=1970-01-01".to_string(),
+            },
+        ];
+
+        assert!(matches_filters(
+            &result(&in_scope, "main.rs", 13, 101),
+            ViewKind::Patra,
+            Some(dir.path()),
+            &niyamas
+        ));
+        assert!(!matches_filters(
+            &result(&out_scope, "main.rs", 13, 101),
+            ViewKind::Patra,
+            Some(dir.path()),
+            &niyamas
+        ));
+        assert!(!matches_filters(
+            &result(&in_scope, "main.rs", 13, 99),
+            ViewKind::Patra,
+            Some(dir.path()),
+            &niyamas
+        ));
+    }
+
+    #[test]
+    fn preview_file_sanitizes_controls_and_assigns_highlight_styles() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("main.rs");
+        std::fs::write(&file, "fn main() {\n\tprintln!(\"hi\");\n\u{1b}[31m\n}\n").unwrap();
+        let (syntaxes, themes) = test_syntaxes_and_theme();
+        let theme = pick_theme(&themes);
+
+        let (title, lines, truncated, error) =
+            build_preview(file.to_str().unwrap(), &syntaxes, theme);
+
+        assert_eq!(title, "main.rs");
+        assert!(!truncated);
+        assert!(error.is_none());
+        let rendered = lines
+            .iter()
+            .flat_map(|line| line.iter().map(|seg| seg.text.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("println!"));
+        assert!(rendered.contains("    "));
+        assert!(lines.iter().flatten().any(|seg| seg.style.fg.is_some()));
+    }
+
+    #[test]
+    fn preview_binary_file_is_marked_truncated_without_decoding() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("archive.bin");
+        std::fs::write(&file, b"abc\0def").unwrap();
+        let (syntaxes, themes) = test_syntaxes_and_theme();
+        let theme = pick_theme(&themes);
+
+        let (title, lines, truncated, error) =
+            build_preview(file.to_str().unwrap(), &syntaxes, theme);
+
+        assert_eq!(title, "archive.bin");
+        assert!(truncated);
+        assert!(error.is_none());
+        assert!(lines
+            .iter()
+            .flatten()
+            .any(|seg| seg.text.contains("binary file preview")));
+    }
+
+    #[test]
+    fn preview_directory_lists_entries_and_marks_directories() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("README.md"), "readme").unwrap();
+        let (syntaxes, themes) = test_syntaxes_and_theme();
+        let theme = pick_theme(&themes);
+
+        let (_title, lines, truncated, error) =
+            build_preview(dir.path().to_str().unwrap(), &syntaxes, theme);
+
+        assert!(!truncated);
+        assert!(error.is_none());
+        let rendered = lines
+            .iter()
+            .flat_map(|line| line.iter().map(|seg| seg.text.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("README.md"));
+        assert!(rendered.contains("src/"));
+    }
+
+    #[test]
+    fn preview_directory_truncates_large_listing() {
+        let dir = tempdir().unwrap();
+        for i in 0..205 {
+            std::fs::write(dir.path().join(format!("file-{i:03}.txt")), "").unwrap();
+        }
+        let (syntaxes, themes) = test_syntaxes_and_theme();
+        let theme = pick_theme(&themes);
+
+        let (_title, lines, truncated, error) =
+            build_preview(dir.path().to_str().unwrap(), &syntaxes, theme);
+
+        assert!(truncated);
+        assert!(error.is_none());
+        assert!(lines
+            .iter()
+            .flatten()
+            .any(|seg| seg.text.contains("showing first 200 entries")));
+    }
+
+    #[test]
+    fn preview_missing_path_returns_error_line() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("missing.txt");
+        let (syntaxes, themes) = test_syntaxes_and_theme();
+        let theme = pick_theme(&themes);
+
+        let (_title, lines, truncated, error) =
+            build_preview(missing.to_str().unwrap(), &syntaxes, theme);
+
+        assert!(!truncated);
+        assert!(error.is_some());
+        assert!(lines.iter().flatten().any(|seg| {
+            seg.style.kind == TextKind::Error && seg.text.contains("unable to read metadata")
+        }));
+    }
+
+    fn start_fake_daemon(
+        vicaya_dir: &std::path::Path,
+        stop: Arc<AtomicBool>,
+    ) -> std::thread::JoinHandle<Vec<Request>> {
+        let socket = vicaya_dir.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        listener.set_nonblocking(true).unwrap();
+
+        std::thread::spawn(move || {
+            let mut requests = Vec::new();
+            while !stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream.set_nonblocking(false).unwrap();
+                        let mut reader = BufReader::new(stream.try_clone().unwrap());
+                        let line = vicaya_core::ipc::read_message(&mut reader)
+                            .unwrap()
+                            .unwrap();
+                        let request = Request::from_json(&line).unwrap();
+                        let response = match &request {
+                            Request::Status => Response::Status {
+                                pid: 77,
+                                build: BuildInfo {
+                                    version: "1.2.0".to_string(),
+                                    git_sha: "abc1234".to_string(),
+                                    timestamp: "2026-05-19T00:00:00Z".to_string(),
+                                    target: "aarch64-apple-darwin".to_string(),
+                                },
+                                indexed_files: 3,
+                                trigram_count: 9,
+                                arena_size: 128,
+                                index_allocated_bytes: 256,
+                                state_allocated_bytes: 512,
+                                last_updated: 1_700_000_000,
+                                reconciling: false,
+                            },
+                            Request::Search { .. } => Response::SearchResults {
+                                results: vec![
+                                    vicaya_core::ipc::SearchResult {
+                                        path: "/tmp/repo/src/main.rs".to_string(),
+                                        name: "main.rs".to_string(),
+                                        score: 1.0,
+                                        size: 12,
+                                        mtime: 1_700_000_000,
+                                    },
+                                    vicaya_core::ipc::SearchResult {
+                                        path: "/tmp/repo/target/main.rs".to_string(),
+                                        name: "main.rs".to_string(),
+                                        score: 0.5,
+                                        size: 12,
+                                        mtime: 1_700_000_000,
+                                    },
+                                ],
+                            },
+                            _ => Response::Ok,
+                        };
+                        requests.push(request);
+                        let mut json = response.to_json().unwrap();
+                        json.push('\n');
+                        stream.write_all(json.as_bytes()).unwrap();
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+            requests
+        })
+    }
+
+    #[test]
+    fn worker_loop_coalesces_searches_reports_status_and_builds_preview() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let vicaya_dir = tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", vicaya_dir.path());
+        let stop = Arc::new(AtomicBool::new(false));
+        let fake_daemon = start_fake_daemon(vicaya_dir.path(), stop.clone());
+
+        let preview_dir = tempdir().unwrap();
+        let preview_file = preview_dir.path().join("main.rs");
+        std::fs::write(&preview_file, "fn main() {}\n").unwrap();
+
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+        let (evt_tx, evt_rx) = std::sync::mpsc::channel();
+        let worker = start_worker(cmd_rx, evt_tx);
+
+        cmd_tx
+            .send(WorkerCommand::Search {
+                id: 1,
+                query: "stale".to_string(),
+                limit: 10,
+                view: ViewKind::Patra,
+                boost_scope: Some(std::path::PathBuf::from("/tmp/repo")),
+                filter_scope: Some(std::path::PathBuf::from("/tmp/repo/src")),
+                niyamas: Vec::new(),
+            })
+            .unwrap();
+        cmd_tx
+            .send(WorkerCommand::Search {
+                id: 2,
+                query: "main".to_string(),
+                limit: 10,
+                view: ViewKind::Patra,
+                boost_scope: Some(std::path::PathBuf::from("/tmp/repo")),
+                filter_scope: Some(std::path::PathBuf::from("/tmp/repo/src")),
+                niyamas: vec![Niyama::Path {
+                    needle: "src".to_string(),
+                    raw: "path:src".to_string(),
+                }],
+            })
+            .unwrap();
+        cmd_tx
+            .send(WorkerCommand::Preview {
+                id: 9,
+                path: preview_file.to_string_lossy().to_string(),
+            })
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut saw_status = false;
+        let mut saw_search = false;
+        let mut saw_preview = false;
+        while std::time::Instant::now() < deadline {
+            if let Ok(event) = evt_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                match event {
+                    WorkerEvent::Status { status } => {
+                        saw_status = status
+                            .as_ref()
+                            .is_some_and(|status| status.indexed_files == 3);
+                    }
+                    WorkerEvent::SearchResults { id, results, error } => {
+                        if id == 2 {
+                            assert!(error.is_none());
+                            assert_eq!(results.len(), 1);
+                            assert!(results[0].path.contains("/src/"));
+                            saw_search = true;
+                        }
+                    }
+                    WorkerEvent::PreviewReady {
+                        id,
+                        title,
+                        lines,
+                        truncated,
+                        ..
+                    } => {
+                        if id == 9 {
+                            assert_eq!(title, "main.rs");
+                            assert!(!truncated);
+                            let rendered = lines
+                                .iter()
+                                .flatten()
+                                .map(|seg| seg.text.as_str())
+                                .collect::<Vec<_>>()
+                                .join("");
+                            assert!(rendered.contains("main"));
+                            saw_preview = true;
+                        }
+                    }
+                }
+            }
+            if saw_status && saw_search && saw_preview {
+                break;
+            }
+        }
+
+        cmd_tx.send(WorkerCommand::Quit).unwrap();
+        worker.join().unwrap();
+        stop.store(true, Ordering::Relaxed);
+        let requests = fake_daemon.join().unwrap();
+
+        assert!(saw_status, "worker did not report daemon status");
+        assert!(saw_search, "worker did not report latest search results");
+        assert!(saw_preview, "worker did not report preview");
+        assert!(requests.iter().any(|req| matches!(req, Request::Status)));
+        assert!(requests
+            .iter()
+            .any(|req| { matches!(req, Request::Search { query, .. } if query == "main") }));
+        assert!(!requests
+            .iter()
+            .any(|req| { matches!(req, Request::Search { query, .. } if query == "stale") }));
     }
 }

--- a/crates/vicaya-tui/src/worker.rs
+++ b/crates/vicaya-tui/src/worker.rs
@@ -884,7 +884,6 @@ mod tests {
 
         let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
         let (evt_tx, evt_rx) = std::sync::mpsc::channel();
-        let worker = start_worker(cmd_rx, evt_tx);
 
         cmd_tx
             .send(WorkerCommand::Search {
@@ -917,6 +916,8 @@ mod tests {
                 path: preview_file.to_string_lossy().to_string(),
             })
             .unwrap();
+
+        let worker = start_worker(cmd_rx, evt_tx);
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         let mut saw_status = false;


### PR DESCRIPTION
## Summary
- Raise workspace coverage above 85% with focused CLI, TUI, daemon, and worker tests.
- Ignore local codemap and log artifacts.

## Validation
- make check
- cargo llvm-cov --workspace --all-features --summary-only: 85.16% lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit and integration test coverage across CLI, daemon, and TUI components, including end-to-end operational workflow validation.

* **Chores**
  * Updated build artifact and log file ignore patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/indrasvat/vicaya/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->