### PR TITLE
fix(release): support workspace version inheritance

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,19 +1,21 @@
 {
-  "release-type": "rust",
+  "release-type": "simple",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "draft": true,
-  "plugins": [
-    {
-      "type": "cargo-workspace",
-      "merge": false
-    }
-  ],
   "packages": {
     ".": {
+      "release-type": "simple",
       "package-name": "vicaya",
       "component": "vicaya",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- switch Release Please to the simple strategy for workspace.package versioning
- update root Cargo.toml through an explicit TOML updater
- keep Release Please from editing member crates that use version.workspace

## Validation
- make ci via pre-push
- release-please release-pr --dry-run