### PR TITLE
fix(ci): measure binary crate coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: lcov.info
           fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -34,7 +34,6 @@ comment:
   require_head: true
 
 ignore:
-  - "crates/*/src/main.rs"  # Ignore main entry points
   - "crates/*/tests/**"      # Ignore test code itself
   - "**/*_test.rs"
 


### PR DESCRIPTION
## Summary
- stop ignoring Rust binary crate main files in Codecov
- keep test-code ignores intact

## Validation
- make ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to include main entry points in coverage metrics while ensuring test code patterns are properly excluded from coverage reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/indrasvat/vicaya/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->