### PR TITLE
perf(tui): restore fast scoped search

### DIFF
--- a/crates/vicaya-cli/src/main.rs
+++ b/crates/vicaya-cli/src/main.rs
@@ -182,12 +182,7 @@ fn search(query: &str, limit: usize, format: &str, scope: Option<&Path>) -> Resu
     let response = IpcClient::connect()?.request(&request)?;
 
     match response {
-        Response::SearchResults { mut results } => {
-            if results.is_empty() {
-                if let Some(retry) = wait_for_reconcile_and_retry(&request, format)? {
-                    results = retry;
-                }
-            }
+        Response::SearchResults { results } => {
             match format {
                 "json" => {
                     println!("{}", serde_json::to_string_pretty(&results).unwrap());
@@ -225,45 +220,6 @@ fn search(query: &str, limit: usize, format: &str, scope: Option<&Path>) -> Resu
             Ok(())
         }
     }
-}
-
-fn wait_for_reconcile_and_retry(
-    search_request: &Request,
-    format: &str,
-) -> Result<Option<Vec<vicaya_core::ipc::SearchResult>>> {
-    use std::time::{Duration, Instant};
-
-    let reconciling = match IpcClient::connect()?.request(&Request::Status)? {
-        Response::Status { reconciling, .. } => reconciling,
-        _ => return Ok(None),
-    };
-
-    if !reconciling {
-        return Ok(None);
-    }
-
-    if format != "json" {
-        eprintln!("Index is reconciling; waiting for results...");
-    }
-
-    let deadline = Instant::now() + Duration::from_secs(120);
-
-    while Instant::now() < deadline {
-        let reconciling = match IpcClient::connect()?.request(&Request::Status)? {
-            Response::Status { reconciling, .. } => reconciling,
-            _ => false,
-        };
-        if !reconciling {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(250));
-    }
-
-    let Response::SearchResults { results } = IpcClient::connect()?.request(search_request)? else {
-        return Ok(None);
-    };
-
-    Ok(Some(results))
 }
 
 fn rebuild(dry_run: bool) -> Result<()> {

--- a/crates/vicaya-daemon/src/ipc_server.rs
+++ b/crates/vicaya-daemon/src/ipc_server.rs
@@ -16,6 +16,7 @@ use vicaya_scanner::{IndexSnapshot, Scanner};
 use vicaya_watcher::IndexUpdate;
 
 pub type SharedState = Arc<RwLock<DaemonState>>;
+const RECENT_UPDATE_LIMIT: usize = 4096;
 
 /// Shared daemon state.
 pub struct DaemonState {
@@ -27,11 +28,91 @@ pub struct DaemonState {
     pub path_to_id: std::collections::HashMap<u64, FileId>,
     pub path_hash_collisions: std::collections::HashMap<u64, Vec<FileId>>,
     pub path_order: Vec<FileId>,
+    pub path_order_dirty: bool,
     pub name_to_ids: std::collections::HashMap<String, Vec<FileId>>,
     pub recent_order: Vec<FileId>,
+    pub recent_updates: Vec<FileId>,
     pub inode_to_id: std::collections::HashMap<(u64, u64), FileId>,
     pub last_updated: i64,
     pub reconciling: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum PreparedIndexUpdate {
+    CreateOrModify {
+        file: Option<PreparedFileMeta>,
+    },
+    Delete {
+        path: PathBuf,
+    },
+    Move {
+        from: PathBuf,
+        file: Option<PreparedFileMeta>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedFileMeta {
+    path: String,
+    name: String,
+    size: u64,
+    mtime: i64,
+    dev: u64,
+    ino: u64,
+}
+
+pub(crate) fn prepare_index_update(config: &Config, update: IndexUpdate) -> PreparedIndexUpdate {
+    match update {
+        IndexUpdate::Create { path } | IndexUpdate::Modify { path } => {
+            let path = PathBuf::from(path);
+            PreparedIndexUpdate::CreateOrModify {
+                file: prepare_file_meta(config, &path),
+            }
+        }
+        IndexUpdate::Delete { path } => PreparedIndexUpdate::Delete {
+            path: PathBuf::from(path),
+        },
+        IndexUpdate::Move { from, to } => {
+            let to = PathBuf::from(to);
+            PreparedIndexUpdate::Move {
+                from: PathBuf::from(from),
+                file: prepare_file_meta(config, &to),
+            }
+        }
+    }
+}
+
+fn prepare_file_meta(config: &Config, path: &Path) -> Option<PreparedFileMeta> {
+    if !vicaya_core::filter::should_index_path(path, &config.exclusions) {
+        return None;
+    }
+
+    let metadata = std::fs::metadata(path).ok()?;
+    if !(metadata.is_file() || metadata.is_dir()) {
+        return None;
+    }
+
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
+
+    let name = path.file_name()?.to_string_lossy().to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    Some(PreparedFileMeta {
+        path: path.to_string_lossy().to_string(),
+        name,
+        size: metadata.len(),
+        mtime: metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0),
+        dev: metadata.dev(),
+        ino: metadata.ino(),
+    })
 }
 
 impl DaemonState {
@@ -64,8 +145,10 @@ impl DaemonState {
             path_to_id,
             path_hash_collisions,
             path_order,
+            path_order_dirty: false,
             name_to_ids,
             recent_order,
+            recent_updates: Vec::new(),
             inode_to_id,
             last_updated,
             reconciling: false,
@@ -73,21 +156,24 @@ impl DaemonState {
     }
 
     pub fn apply_update(&mut self, update: IndexUpdate) {
-        match update {
-            IndexUpdate::Create { path } | IndexUpdate::Modify { path } => {
-                self.upsert_path(Path::new(&path));
-            }
-            IndexUpdate::Delete { path } => {
-                self.remove_path(Path::new(&path));
-            }
-            IndexUpdate::Move { from, to } => {
-                self.move_path(Path::new(&from), Path::new(&to));
-            }
-        }
+        let update = prepare_index_update(&self.config, update);
+        self.apply_prepared_update(update);
     }
 
-    fn should_index(&self, path: &Path) -> bool {
-        vicaya_core::filter::should_index_path(path, &self.config.exclusions)
+    pub(crate) fn apply_prepared_update(&mut self, update: PreparedIndexUpdate) {
+        match update {
+            PreparedIndexUpdate::CreateOrModify { file } => {
+                if let Some(file) = file {
+                    self.upsert_prepared(file);
+                }
+            }
+            PreparedIndexUpdate::Delete { path } => {
+                self.remove_path(&path);
+            }
+            PreparedIndexUpdate::Move { from, file } => {
+                self.move_prepared(&from, file);
+            }
+        }
     }
 
     fn indexed_file_count(&self) -> usize {
@@ -124,6 +210,7 @@ impl DaemonState {
                 .map(|ids| ids.capacity() * std::mem::size_of::<FileId>())
                 .sum::<usize>()
             + self.recent_order.capacity() * std::mem::size_of::<FileId>()
+            + self.recent_updates.capacity() * std::mem::size_of::<FileId>()
             + hash_map_allocated_bytes(&self.inode_to_id)) as u64
     }
 
@@ -182,37 +269,15 @@ impl DaemonState {
             .insert(hash, vec![existing, file_id]);
     }
 
-    fn insert_path_order(&mut self, file_id: FileId) {
-        let Some(path) = snapshot_path_for_id(&self.snapshot, file_id) else {
-            return;
-        };
-        if path.is_empty() {
-            return;
-        }
-
-        let pos = self.path_order.partition_point(|&id| {
-            snapshot_path_for_id(&self.snapshot, id).is_some_and(|existing| existing < path)
-        });
-        self.path_order.insert(pos, file_id);
-    }
-
-    fn remove_path_order(&mut self, file_id: FileId, path: &str) {
-        let start = self.path_order.partition_point(|&id| {
-            snapshot_path_for_id(&self.snapshot, id).is_some_and(|existing| existing < path)
-        });
-        let end = self.path_order[start..]
-            .partition_point(|&id| snapshot_path_for_id(&self.snapshot, id) == Some(path))
-            + start;
-
-        if let Some(pos) = self.path_order[start..end]
-            .iter()
-            .position(|&id| id == file_id)
-        {
-            self.path_order.remove(start + pos);
-        }
+    fn mark_path_order_dirty(&mut self) {
+        self.path_order_dirty = true;
     }
 
     fn scoped_file_ids_up_to(&self, scope: &Path, max_ids: usize) -> Option<(Vec<FileId>, bool)> {
+        if self.path_order_dirty {
+            return None;
+        }
+
         let (scope, scope_child_prefix) = normalized_scope_parts(scope)?;
         let start = self.path_order.partition_point(|&id| {
             snapshot_path_for_id(&self.snapshot, id).is_some_and(|path| path < scope.as_str())
@@ -238,20 +303,40 @@ impl DaemonState {
         Some((ids, true))
     }
 
-    fn recent_file_ids_in_scope(&self, limit: usize, scope: &Path) -> Option<Vec<FileId>> {
-        let (scope, scope_child_prefix) = normalized_scope_parts(scope)?;
+    fn recent_file_ids(&self, limit: usize, scope: Option<&Path>) -> Option<Vec<FileId>> {
+        let scope = scope.and_then(normalized_scope_parts);
+        let mut seen = std::collections::HashSet::with_capacity(limit.saturating_mul(2));
         let mut ids = Vec::with_capacity(limit);
 
-        for &file_id in &self.recent_order {
+        for file_id in self
+            .recent_updates
+            .iter()
+            .rev()
+            .chain(self.recent_order.iter())
+            .copied()
+        {
+            if ids.len() == limit {
+                break;
+            }
+            if !seen.insert(file_id) {
+                continue;
+            }
+            let Some(meta) = self.snapshot.file_table.get(file_id) else {
+                continue;
+            };
+            if meta.path_len == 0 || meta.name_len == 0 {
+                continue;
+            }
             let Some(path) = snapshot_path_for_id(&self.snapshot, file_id) else {
                 continue;
             };
-            if path_is_in_normalized_scope(path, &scope, &scope_child_prefix) {
-                ids.push(file_id);
-                if ids.len() == limit {
-                    break;
+            if let Some((scope, scope_child_prefix)) = scope.as_ref() {
+                if !path_is_in_normalized_scope(path, scope, scope_child_prefix) {
+                    continue;
                 }
             }
+
+            ids.push(file_id);
         }
 
         Some(ids)
@@ -311,27 +396,23 @@ impl DaemonState {
         }
     }
 
-    fn insert_recent_order(&mut self, file_id: FileId) {
+    fn mark_recent_update(&mut self, file_id: FileId) {
         let Some(meta) = self.snapshot.file_table.get(file_id) else {
             return;
         };
         if meta.path_len == 0 || meta.name_len == 0 {
             return;
         }
-        let mtime = meta.mtime;
-        let pos = self.recent_order.partition_point(|&id| {
-            let Some(existing) = self.snapshot.file_table.get(id) else {
-                return false;
-            };
-            existing.mtime > mtime || (existing.mtime == mtime && id < file_id)
-        });
-        self.recent_order.insert(pos, file_id);
+        self.recent_updates.retain(|&id| id != file_id);
+        self.recent_updates.push(file_id);
+        if self.recent_updates.len() > RECENT_UPDATE_LIMIT {
+            let excess = self.recent_updates.len() - RECENT_UPDATE_LIMIT;
+            self.recent_updates.drain(0..excess);
+        }
     }
 
-    fn remove_recent_order(&mut self, file_id: FileId) {
-        if let Some(pos) = self.recent_order.iter().position(|&id| id == file_id) {
-            self.recent_order.remove(pos);
-        }
+    fn remove_recent_update(&mut self, file_id: FileId) {
+        self.recent_updates.retain(|&id| id != file_id);
     }
 
     fn remove_path_mapping(&mut self, path: &str) -> Option<FileId> {
@@ -376,45 +457,12 @@ impl DaemonState {
         Some(file_id)
     }
 
-    fn upsert_path(&mut self, path: &Path) {
-        if !self.should_index(path) {
-            return;
-        }
+    fn upsert_prepared(&mut self, file: PreparedFileMeta) {
+        let path_str = file.path.as_str();
+        let name_str = file.name.as_str();
+        let inode_key = (file.dev, file.ino);
 
-        let metadata = match std::fs::metadata(path) {
-            Ok(m) => m,
-            Err(_) => return,
-        };
-        if !(metadata.is_file() || metadata.is_dir()) {
-            return;
-        }
-
-        #[cfg(unix)]
-        use std::os::unix::fs::MetadataExt;
-
-        let mtime = metadata
-            .modified()
-            .ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
-
-        let dev = metadata.dev();
-        let ino = metadata.ino();
-        let size = metadata.len();
-
-        let path_str = path.to_string_lossy();
-        let name_str = path
-            .file_name()
-            .map(|n| n.to_string_lossy())
-            .unwrap_or_default();
-        if name_str.is_empty() {
-            return;
-        }
-
-        let inode_key = (dev, ino);
-
-        if let Some(file_id) = self.get_file_id_for_path(path_str.as_ref()) {
+        if let Some(file_id) = self.get_file_id_for_path(path_str) {
             let (old_inode_key, old_name) = {
                 let Some(meta) = self.snapshot.file_table.get(file_id) else {
                     return;
@@ -428,8 +476,7 @@ impl DaemonState {
                 ((meta.dev, meta.ino), old_name)
             };
 
-            self.remove_recent_order(file_id);
-            if old_name != name_str.as_ref() {
+            if old_name != name_str {
                 self.remove_name_mapping(file_id, &old_name);
             }
 
@@ -444,24 +491,24 @@ impl DaemonState {
                 self.inode_to_id.insert(inode_key, file_id);
             }
 
-            if old_name != name_str.as_ref() {
+            if old_name != name_str {
                 self.snapshot.trigram_index.remove_text(file_id, &old_name);
-                self.snapshot.trigram_index.add(file_id, name_str.as_ref());
+                self.snapshot.trigram_index.add(file_id, name_str);
 
-                let (name_offset, name_len) = self.snapshot.string_arena.add(name_str.as_ref());
+                let (name_offset, name_len) = self.snapshot.string_arena.add(name_str);
                 meta.name_offset = name_offset;
                 meta.name_len = name_len;
             }
 
-            meta.size = size;
-            meta.mtime = mtime;
-            meta.dev = dev;
-            meta.ino = ino;
+            meta.size = file.size;
+            meta.mtime = file.mtime;
+            meta.dev = file.dev;
+            meta.ino = file.ino;
 
-            if old_name != name_str.as_ref() {
+            if old_name != name_str {
                 self.insert_name_mapping(file_id);
             }
-            self.insert_recent_order(file_id);
+            self.mark_recent_update(file_id);
         } else if let Some(&file_id) = self.inode_to_id.get(&inode_key) {
             // Same inode (dev+ino) already exists in the index under a different path; treat this
             // as a move/rename even if the watcher didn't report the old path.
@@ -489,10 +536,8 @@ impl DaemonState {
 
             if !old_path.is_empty() {
                 let _ = self.remove_path_mapping(&old_path);
-                self.remove_path_order(file_id, &old_path);
             }
-            self.remove_recent_order(file_id);
-            if old_name != name_str.as_ref() {
+            if old_name != name_str {
                 self.remove_name_mapping(file_id, &old_name);
             }
 
@@ -500,50 +545,50 @@ impl DaemonState {
                 return;
             };
 
-            if old_name != name_str.as_ref() {
+            if old_name != name_str {
                 self.snapshot.trigram_index.remove_text(file_id, &old_name);
-                self.snapshot.trigram_index.add(file_id, name_str.as_ref());
+                self.snapshot.trigram_index.add(file_id, name_str);
 
-                let (name_offset, name_len) = self.snapshot.string_arena.add(name_str.as_ref());
+                let (name_offset, name_len) = self.snapshot.string_arena.add(name_str);
                 meta.name_offset = name_offset;
                 meta.name_len = name_len;
             }
 
-            let (path_offset, path_len) = self.snapshot.string_arena.add(path_str.as_ref());
+            let (path_offset, path_len) = self.snapshot.string_arena.add(path_str);
             meta.path_offset = path_offset;
             meta.path_len = path_len;
-            meta.size = size;
-            meta.mtime = mtime;
-            meta.dev = dev;
-            meta.ino = ino;
+            meta.size = file.size;
+            meta.mtime = file.mtime;
+            meta.dev = file.dev;
+            meta.ino = file.ino;
 
-            self.insert_path_mapping(path_str.as_ref(), file_id);
-            self.insert_path_order(file_id);
-            if old_name != name_str.as_ref() {
+            self.insert_path_mapping(path_str, file_id);
+            self.mark_path_order_dirty();
+            if old_name != name_str {
                 self.insert_name_mapping(file_id);
             }
-            self.insert_recent_order(file_id);
+            self.mark_recent_update(file_id);
         } else {
-            let (path_offset, path_len) = self.snapshot.string_arena.add(path_str.as_ref());
-            let (name_offset, name_len) = self.snapshot.string_arena.add(name_str.as_ref());
+            let (path_offset, path_len) = self.snapshot.string_arena.add(path_str);
+            let (name_offset, name_len) = self.snapshot.string_arena.add(name_str);
 
             let new_meta = FileMeta {
                 path_offset,
                 path_len,
                 name_offset,
                 name_len,
-                size,
-                mtime,
-                dev,
-                ino,
+                size: file.size,
+                mtime: file.mtime,
+                dev: file.dev,
+                ino: file.ino,
             };
 
             let file_id = self.snapshot.file_table.insert(new_meta);
-            self.snapshot.trigram_index.add(file_id, name_str.as_ref());
-            self.insert_path_mapping(path_str.as_ref(), file_id);
-            self.insert_path_order(file_id);
+            self.snapshot.trigram_index.add(file_id, name_str);
+            self.insert_path_mapping(path_str, file_id);
+            self.mark_path_order_dirty();
             self.insert_name_mapping(file_id);
-            self.insert_recent_order(file_id);
+            self.mark_recent_update(file_id);
             self.inode_to_id.insert(inode_key, file_id);
         }
 
@@ -555,8 +600,6 @@ impl DaemonState {
         let Some(file_id) = self.remove_path_mapping(path_str.as_ref()) else {
             return;
         };
-        self.remove_path_order(file_id, path_str.as_ref());
-        self.remove_recent_order(file_id);
 
         self.tombstone_file(file_id);
     }
@@ -579,6 +622,8 @@ impl DaemonState {
             self.inode_to_id.remove(&inode_key);
         }
 
+        self.mark_path_order_dirty();
+        self.remove_recent_update(file_id);
         self.snapshot.trigram_index.remove_text(file_id, &old_name);
         self.remove_name_mapping(file_id, &old_name);
 
@@ -595,64 +640,30 @@ impl DaemonState {
         self.last_updated = now_epoch_seconds();
     }
 
-    fn move_path(&mut self, from: &Path, to: &Path) {
+    fn move_prepared(&mut self, from: &Path, file: Option<PreparedFileMeta>) {
         let from_str = from.to_string_lossy();
         let Some(file_id) = self.remove_path_mapping(from_str.as_ref()) else {
             // If we didn't know about the old path, treat as a create on the new path.
-            self.upsert_path(to);
-            return;
-        };
-        self.remove_path_order(file_id, from_str.as_ref());
-        self.remove_recent_order(file_id);
-
-        if !self.should_index(to) {
-            self.tombstone_file(file_id);
-            return;
-        }
-
-        let metadata = match std::fs::metadata(to) {
-            Ok(m) => m,
-            Err(_) => {
-                self.tombstone_file(file_id);
-                return;
+            if let Some(file) = file {
+                self.upsert_prepared(file);
             }
+            return;
         };
-        if !(metadata.is_file() || metadata.is_dir()) {
+
+        let Some(file) = file else {
             self.tombstone_file(file_id);
             return;
-        }
+        };
 
-        #[cfg(unix)]
-        use std::os::unix::fs::MetadataExt;
-
-        let mtime = metadata
-            .modified()
-            .ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
-
-        let dev = metadata.dev();
-        let ino = metadata.ino();
-        let size = metadata.len();
-
-        let to_str = to.to_string_lossy();
-        let name_str = to
-            .file_name()
-            .map(|n| n.to_string_lossy())
-            .unwrap_or_default();
-        if name_str.is_empty() {
-            self.tombstone_file(file_id);
-            return;
-        }
+        let to_str = file.path.as_str();
+        let name_str = file.name.as_str();
 
         if let Some(overwritten_id) = self
-            .get_file_id_for_path(to_str.as_ref())
+            .get_file_id_for_path(to_str)
             .filter(|&existing_id| existing_id != file_id)
         {
-            let _ = self.remove_path_mapping(to_str.as_ref());
-            self.remove_path_order(overwritten_id, to_str.as_ref());
-            self.remove_recent_order(overwritten_id);
+            let _ = self.remove_path_mapping(to_str);
+            self.remove_recent_update(overwritten_id);
             self.tombstone_file(overwritten_id);
         }
 
@@ -669,32 +680,32 @@ impl DaemonState {
             ((meta.dev, meta.ino), old_name)
         };
 
-        if old_name != name_str.as_ref() {
+        if old_name != name_str {
             self.remove_name_mapping(file_id, &old_name);
             self.snapshot.trigram_index.remove_text(file_id, &old_name);
-            self.snapshot.trigram_index.add(file_id, name_str.as_ref());
+            self.snapshot.trigram_index.add(file_id, name_str);
         }
 
         let Some(meta) = self.snapshot.file_table.get_mut(file_id) else {
             return;
         };
 
-        if old_name != name_str.as_ref() {
-            let (name_offset, name_len) = self.snapshot.string_arena.add(name_str.as_ref());
+        if old_name != name_str {
+            let (name_offset, name_len) = self.snapshot.string_arena.add(name_str);
             meta.name_offset = name_offset;
             meta.name_len = name_len;
         }
 
-        let (path_offset, path_len) = self.snapshot.string_arena.add(to_str.as_ref());
+        let (path_offset, path_len) = self.snapshot.string_arena.add(to_str);
 
         meta.path_offset = path_offset;
         meta.path_len = path_len;
-        meta.size = size;
-        meta.mtime = mtime;
-        meta.dev = dev;
-        meta.ino = ino;
+        meta.size = file.size;
+        meta.mtime = file.mtime;
+        meta.dev = file.dev;
+        meta.ino = file.ino;
 
-        let new_inode_key = (dev, ino);
+        let new_inode_key = (file.dev, file.ino);
         if old_inode_key != new_inode_key {
             if self.inode_to_id.get(&old_inode_key) == Some(&file_id) {
                 self.inode_to_id.remove(&old_inode_key);
@@ -704,12 +715,12 @@ impl DaemonState {
             self.inode_to_id.insert(new_inode_key, file_id);
         }
 
-        self.insert_path_mapping(to_str.as_ref(), file_id);
-        self.insert_path_order(file_id);
-        if old_name != name_str.as_ref() {
+        self.insert_path_mapping(to_str, file_id);
+        self.mark_path_order_dirty();
+        if old_name != name_str {
             self.insert_name_mapping(file_id);
         }
-        self.insert_recent_order(file_id);
+        self.mark_recent_update(file_id);
         self.last_updated = now_epoch_seconds();
     }
 }
@@ -927,6 +938,19 @@ fn truncate_journal(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+fn replace_state(state: &SharedState, rebuilt: DaemonState) {
+    let old_state = {
+        let mut state = state.write().unwrap();
+        std::mem::replace(&mut *state, rebuilt)
+    };
+
+    // Dropping a multi-GB old state can monopolize allocator locks and stall
+    // foreground IPC threads even though the daemon state lock has been
+    // released. Rebuilds are rare; keep the retired state until process exit so
+    // status/search stay responsive through reconcile completion.
+    std::mem::forget(old_state);
+}
+
 pub fn full_rebuild_from_disk(
     state: &SharedState,
     journal_lock: &Arc<Mutex<()>>,
@@ -978,8 +1002,7 @@ pub fn full_rebuild_from_disk(
             rebuilt.last_updated = now_epoch_seconds();
             rebuilt.reconciling = false;
 
-            let mut state = state.write().unwrap();
-            *state = rebuilt;
+            replace_state(state, rebuilt);
             applied_updates
         };
 
@@ -1178,14 +1201,11 @@ impl IpcHandler {
                 let results = if query.trim().is_empty() && recent_if_empty {
                     if let Some((file_ids, true)) = scoped_file_ids.as_ref() {
                         engine.recent_file_ids(limit, file_ids)
-                    } else if let Some(scope) = filter_scope_path.as_deref() {
+                    } else {
                         let file_ids = state
-                            .recent_file_ids_in_scope(limit, scope)
+                            .recent_file_ids(limit, filter_scope_path.as_deref())
                             .unwrap_or_default();
                         engine.recent_file_ids(limit, &file_ids)
-                    } else {
-                        let end = state.recent_order.len().min(limit);
-                        engine.recent_file_ids(limit, &state.recent_order[..end])
                     }
                 } else if let Some(file_ids) = exact_name_file_ids.as_deref() {
                     engine.exact_name_file_ids(limit, file_ids)
@@ -1355,7 +1375,10 @@ mod tests {
         let file_id = state.get_file_id_for_path(&from.to_string_lossy()).unwrap();
 
         std::fs::rename(&from, &to).unwrap();
-        state.move_path(&from, &to);
+        state.apply_update(IndexUpdate::Move {
+            from: from.to_string_lossy().to_string(),
+            to: to.to_string_lossy().to_string(),
+        });
 
         assert!(state
             .get_file_id_for_path(&from.to_string_lossy())
@@ -1390,7 +1413,10 @@ mod tests {
         let overwritten_inode = inode_key_for(&state, overwritten_id);
 
         std::fs::rename(&from, &to).unwrap();
-        state.move_path(&from, &to);
+        state.apply_update(IndexUpdate::Move {
+            from: from.to_string_lossy().to_string(),
+            to: to.to_string_lossy().to_string(),
+        });
 
         assert!(state
             .get_file_id_for_path(&from.to_string_lossy())
@@ -1620,6 +1646,22 @@ mod tests {
     }
 
     #[test]
+    fn scoped_file_id_cache_is_disabled_after_incremental_path_changes() {
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let mut state = build_state(root.path(), vicaya_dir.path());
+
+        let new_file = root.path().join("new.txt");
+        std::fs::write(&new_file, "new").unwrap();
+        state.apply_update(IndexUpdate::Create {
+            path: new_file.to_string_lossy().to_string(),
+        });
+
+        assert!(state.path_order_dirty);
+        assert!(state.scoped_file_ids_up_to(root.path(), 10).is_none());
+    }
+
+    #[test]
     fn exact_name_search_is_filtered_inside_scope() {
         let vicaya_dir = tempdir().unwrap();
         let root = tempdir().unwrap();
@@ -1719,6 +1761,86 @@ mod tests {
 
         drop(reader);
         drop(stream);
+        server_thread.join().unwrap();
+        assert!(shutdown.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn ipc_server_handles_multiple_tui_clients_concurrently() {
+        use std::io::Write as _;
+        use std::os::unix::net::UnixStream;
+
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cargo = root.path().join("Cargo.toml");
+        std::fs::write(&cargo, "[package]\n").unwrap();
+
+        let state = Arc::new(RwLock::new(build_state(root.path(), vicaya_dir.path())));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let journal_lock = Arc::new(Mutex::new(()));
+        let rebuild_lock = Arc::new(Mutex::new(()));
+        let socket = vicaya_dir.path().join("daemon.sock");
+        let server =
+            IpcServer::new(&socket, state, shutdown.clone(), journal_lock, rebuild_lock).unwrap();
+        let server_thread = std::thread::spawn(move || server.run().unwrap());
+
+        let mut clients = Vec::new();
+        for _ in 0..4 {
+            let socket = socket.clone();
+            let scope = root.path().to_string_lossy().to_string();
+            clients.push(std::thread::spawn(move || {
+                let mut stream = UnixStream::connect(&socket).unwrap();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+
+                let send = |stream: &mut UnixStream, request: Request| {
+                    let mut json = request.to_json().unwrap();
+                    json.push('\n');
+                    stream.write_all(json.as_bytes()).unwrap();
+                };
+
+                send(&mut stream, Request::Status);
+                let line = vicaya_core::ipc::read_message(&mut reader)
+                    .unwrap()
+                    .unwrap();
+                assert!(matches!(
+                    Response::from_json(&line).unwrap(),
+                    Response::Status { .. }
+                ));
+
+                send(
+                    &mut stream,
+                    Request::Search {
+                        query: "Cargo".to_string(),
+                        limit: 10,
+                        scope: Some(scope.clone()),
+                        filter_scope: Some(scope),
+                        recent_if_empty: false,
+                    },
+                );
+                let line = vicaya_core::ipc::read_message(&mut reader)
+                    .unwrap()
+                    .unwrap();
+                match Response::from_json(&line).unwrap() {
+                    Response::SearchResults { results } => assert_eq!(results.len(), 1),
+                    other => panic!("unexpected concurrent search response: {other:?}"),
+                }
+            }));
+        }
+
+        for client in clients {
+            client.join().unwrap();
+        }
+
+        let mut stream = UnixStream::connect(&socket).unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut json = Request::Shutdown.to_json().unwrap();
+        json.push('\n');
+        stream.write_all(json.as_bytes()).unwrap();
+        let line = vicaya_core::ipc::read_message(&mut reader)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(Response::from_json(&line).unwrap(), Response::Ok));
+
         server_thread.join().unwrap();
         assert!(shutdown.load(Ordering::Relaxed));
     }

--- a/crates/vicaya-daemon/src/ipc_server.rs
+++ b/crates/vicaya-daemon/src/ipc_server.rs
@@ -975,6 +975,7 @@ pub fn full_rebuild_from_disk(
 
             rebuilt.snapshot.save(&index_file)?;
             truncate_journal(&journal_file)?;
+            rebuilt.last_updated = now_epoch_seconds();
             rebuilt.reconciling = false;
 
             let mut state = state.write().unwrap();
@@ -1516,6 +1517,25 @@ mod tests {
 
         truncate_journal(&journal).unwrap();
         assert_eq!(std::fs::metadata(&journal).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn full_rebuild_refreshes_last_updated_after_swap() {
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        std::fs::write(root.path().join("Cargo.toml"), "[package]\n").unwrap();
+
+        let state = Arc::new(RwLock::new(build_state(root.path(), vicaya_dir.path())));
+        state.write().unwrap().last_updated = 0;
+
+        let files_indexed =
+            full_rebuild_from_disk(&state, &Arc::new(Mutex::new(())), &Arc::new(Mutex::new(())))
+                .unwrap();
+
+        assert!(files_indexed >= 1);
+        let state = state.read().unwrap();
+        assert!(state.last_updated > 0);
+        assert!(!state.reconciling);
     }
 
     #[test]

--- a/crates/vicaya-daemon/src/ipc_server.rs
+++ b/crates/vicaya-daemon/src/ipc_server.rs
@@ -26,6 +26,9 @@ pub struct DaemonState {
     pub path_hasher: RandomState,
     pub path_to_id: std::collections::HashMap<u64, FileId>,
     pub path_hash_collisions: std::collections::HashMap<u64, Vec<FileId>>,
+    pub path_order: Vec<FileId>,
+    pub name_to_ids: std::collections::HashMap<String, Vec<FileId>>,
+    pub recent_order: Vec<FileId>,
     pub inode_to_id: std::collections::HashMap<(u64, u64), FileId>,
     pub last_updated: i64,
     pub reconciling: bool,
@@ -40,6 +43,9 @@ impl DaemonState {
     ) -> Self {
         let path_hasher = RandomState::new();
         let (path_to_id, path_hash_collisions) = build_path_map(&snapshot, &path_hasher);
+        let path_order = build_path_order(&snapshot);
+        let name_to_ids = build_name_map(&snapshot);
+        let recent_order = build_recent_order(&snapshot);
         let inode_to_id = build_inode_map(&snapshot);
         let last_updated = index_file
             .metadata()
@@ -57,6 +63,9 @@ impl DaemonState {
             path_hasher,
             path_to_id,
             path_hash_collisions,
+            path_order,
+            name_to_ids,
+            recent_order,
             inode_to_id,
             last_updated,
             reconciling: false,
@@ -107,6 +116,14 @@ impl DaemonState {
             + hash_map_allocated_bytes(&self.path_to_id)
             + hash_map_allocated_bytes(&self.path_hash_collisions)
             + collisions_vec_bytes
+            + self.path_order.capacity() * std::mem::size_of::<FileId>()
+            + hash_map_allocated_bytes(&self.name_to_ids)
+            + self
+                .name_to_ids
+                .values()
+                .map(|ids| ids.capacity() * std::mem::size_of::<FileId>())
+                .sum::<usize>()
+            + self.recent_order.capacity() * std::mem::size_of::<FileId>()
             + hash_map_allocated_bytes(&self.inode_to_id)) as u64
     }
 
@@ -163,6 +180,158 @@ impl DaemonState {
         self.path_to_id.remove(&hash);
         self.path_hash_collisions
             .insert(hash, vec![existing, file_id]);
+    }
+
+    fn insert_path_order(&mut self, file_id: FileId) {
+        let Some(path) = snapshot_path_for_id(&self.snapshot, file_id) else {
+            return;
+        };
+        if path.is_empty() {
+            return;
+        }
+
+        let pos = self.path_order.partition_point(|&id| {
+            snapshot_path_for_id(&self.snapshot, id).is_some_and(|existing| existing < path)
+        });
+        self.path_order.insert(pos, file_id);
+    }
+
+    fn remove_path_order(&mut self, file_id: FileId, path: &str) {
+        let start = self.path_order.partition_point(|&id| {
+            snapshot_path_for_id(&self.snapshot, id).is_some_and(|existing| existing < path)
+        });
+        let end = self.path_order[start..]
+            .partition_point(|&id| snapshot_path_for_id(&self.snapshot, id) == Some(path))
+            + start;
+
+        if let Some(pos) = self.path_order[start..end]
+            .iter()
+            .position(|&id| id == file_id)
+        {
+            self.path_order.remove(start + pos);
+        }
+    }
+
+    fn scoped_file_ids_up_to(&self, scope: &Path, max_ids: usize) -> Option<(Vec<FileId>, bool)> {
+        let (scope, scope_child_prefix) = normalized_scope_parts(scope)?;
+        let start = self.path_order.partition_point(|&id| {
+            snapshot_path_for_id(&self.snapshot, id).is_some_and(|path| path < scope.as_str())
+        });
+
+        let mut ids = Vec::new();
+        for &file_id in &self.path_order[start..] {
+            let Some(path) = snapshot_path_for_id(&self.snapshot, file_id) else {
+                continue;
+            };
+            if path_is_in_normalized_scope(path, &scope, &scope_child_prefix) {
+                ids.push(file_id);
+                if ids.len() > max_ids {
+                    return Some((ids, false));
+                }
+                continue;
+            }
+            if path > scope.as_str() && !path.starts_with(&scope_child_prefix) {
+                break;
+            }
+        }
+
+        Some((ids, true))
+    }
+
+    fn recent_file_ids_in_scope(&self, limit: usize, scope: &Path) -> Option<Vec<FileId>> {
+        let (scope, scope_child_prefix) = normalized_scope_parts(scope)?;
+        let mut ids = Vec::with_capacity(limit);
+
+        for &file_id in &self.recent_order {
+            let Some(path) = snapshot_path_for_id(&self.snapshot, file_id) else {
+                continue;
+            };
+            if path_is_in_normalized_scope(path, &scope, &scope_child_prefix) {
+                ids.push(file_id);
+                if ids.len() == limit {
+                    break;
+                }
+            }
+        }
+
+        Some(ids)
+    }
+
+    fn filter_file_ids_in_scope(&self, file_ids: &[FileId], scope: &Path) -> Option<Vec<FileId>> {
+        let (scope, scope_child_prefix) = normalized_scope_parts(scope)?;
+        Some(
+            file_ids
+                .iter()
+                .copied()
+                .filter(|&file_id| {
+                    snapshot_path_for_id(&self.snapshot, file_id).is_some_and(|path| {
+                        path_is_in_normalized_scope(path, &scope, &scope_child_prefix)
+                    })
+                })
+                .collect(),
+        )
+    }
+
+    fn exact_name_file_ids(&self, query: &str) -> Option<Vec<FileId>> {
+        if !is_exact_basename_query(query) {
+            return None;
+        }
+        let key = query.to_lowercase();
+        self.name_to_ids.get(&key).cloned()
+    }
+
+    fn insert_name_mapping(&mut self, file_id: FileId) {
+        let Some(meta) = self.snapshot.file_table.get(file_id) else {
+            return;
+        };
+        let Some(name) = self
+            .snapshot
+            .string_arena
+            .get(meta.name_offset, meta.name_len)
+        else {
+            return;
+        };
+        if name.is_empty() {
+            return;
+        }
+        self.name_to_ids
+            .entry(name.to_lowercase())
+            .or_default()
+            .push(file_id);
+    }
+
+    fn remove_name_mapping(&mut self, file_id: FileId, name: &str) {
+        let key = name.to_lowercase();
+        let Some(ids) = self.name_to_ids.get_mut(&key) else {
+            return;
+        };
+        ids.retain(|&id| id != file_id);
+        if ids.is_empty() {
+            self.name_to_ids.remove(&key);
+        }
+    }
+
+    fn insert_recent_order(&mut self, file_id: FileId) {
+        let Some(meta) = self.snapshot.file_table.get(file_id) else {
+            return;
+        };
+        if meta.path_len == 0 || meta.name_len == 0 {
+            return;
+        }
+        let mtime = meta.mtime;
+        let pos = self.recent_order.partition_point(|&id| {
+            let Some(existing) = self.snapshot.file_table.get(id) else {
+                return false;
+            };
+            existing.mtime > mtime || (existing.mtime == mtime && id < file_id)
+        });
+        self.recent_order.insert(pos, file_id);
+    }
+
+    fn remove_recent_order(&mut self, file_id: FileId) {
+        if let Some(pos) = self.recent_order.iter().position(|&id| id == file_id) {
+            self.recent_order.remove(pos);
+        }
     }
 
     fn remove_path_mapping(&mut self, path: &str) -> Option<FileId> {
@@ -246,11 +415,28 @@ impl DaemonState {
         let inode_key = (dev, ino);
 
         if let Some(file_id) = self.get_file_id_for_path(path_str.as_ref()) {
+            let (old_inode_key, old_name) = {
+                let Some(meta) = self.snapshot.file_table.get(file_id) else {
+                    return;
+                };
+                let old_name = self
+                    .snapshot
+                    .string_arena
+                    .get(meta.name_offset, meta.name_len)
+                    .unwrap_or("")
+                    .to_string();
+                ((meta.dev, meta.ino), old_name)
+            };
+
+            self.remove_recent_order(file_id);
+            if old_name != name_str.as_ref() {
+                self.remove_name_mapping(file_id, &old_name);
+            }
+
             let Some(meta) = self.snapshot.file_table.get_mut(file_id) else {
                 return;
             };
 
-            let old_inode_key = (meta.dev, meta.ino);
             if old_inode_key != inode_key {
                 if self.inode_to_id.get(&old_inode_key) == Some(&file_id) {
                     self.inode_to_id.remove(&old_inode_key);
@@ -258,14 +444,8 @@ impl DaemonState {
                 self.inode_to_id.insert(inode_key, file_id);
             }
 
-            let old_name = self
-                .snapshot
-                .string_arena
-                .get(meta.name_offset, meta.name_len)
-                .unwrap_or("");
-
             if old_name != name_str.as_ref() {
-                self.snapshot.trigram_index.remove_text(file_id, old_name);
+                self.snapshot.trigram_index.remove_text(file_id, &old_name);
                 self.snapshot.trigram_index.add(file_id, name_str.as_ref());
 
                 let (name_offset, name_len) = self.snapshot.string_arena.add(name_str.as_ref());
@@ -277,6 +457,11 @@ impl DaemonState {
             meta.mtime = mtime;
             meta.dev = dev;
             meta.ino = ino;
+
+            if old_name != name_str.as_ref() {
+                self.insert_name_mapping(file_id);
+            }
+            self.insert_recent_order(file_id);
         } else if let Some(&file_id) = self.inode_to_id.get(&inode_key) {
             // Same inode (dev+ino) already exists in the index under a different path; treat this
             // as a move/rename even if the watcher didn't report the old path.
@@ -304,6 +489,11 @@ impl DaemonState {
 
             if !old_path.is_empty() {
                 let _ = self.remove_path_mapping(&old_path);
+                self.remove_path_order(file_id, &old_path);
+            }
+            self.remove_recent_order(file_id);
+            if old_name != name_str.as_ref() {
+                self.remove_name_mapping(file_id, &old_name);
             }
 
             let Some(meta) = self.snapshot.file_table.get_mut(file_id) else {
@@ -328,6 +518,11 @@ impl DaemonState {
             meta.ino = ino;
 
             self.insert_path_mapping(path_str.as_ref(), file_id);
+            self.insert_path_order(file_id);
+            if old_name != name_str.as_ref() {
+                self.insert_name_mapping(file_id);
+            }
+            self.insert_recent_order(file_id);
         } else {
             let (path_offset, path_len) = self.snapshot.string_arena.add(path_str.as_ref());
             let (name_offset, name_len) = self.snapshot.string_arena.add(name_str.as_ref());
@@ -346,6 +541,9 @@ impl DaemonState {
             let file_id = self.snapshot.file_table.insert(new_meta);
             self.snapshot.trigram_index.add(file_id, name_str.as_ref());
             self.insert_path_mapping(path_str.as_ref(), file_id);
+            self.insert_path_order(file_id);
+            self.insert_name_mapping(file_id);
+            self.insert_recent_order(file_id);
             self.inode_to_id.insert(inode_key, file_id);
         }
 
@@ -357,26 +555,36 @@ impl DaemonState {
         let Some(file_id) = self.remove_path_mapping(path_str.as_ref()) else {
             return;
         };
+        self.remove_path_order(file_id, path_str.as_ref());
+        self.remove_recent_order(file_id);
 
         self.tombstone_file(file_id);
     }
 
     fn tombstone_file(&mut self, file_id: FileId) {
-        let Some(meta) = self.snapshot.file_table.get_mut(file_id) else {
-            return;
+        let (inode_key, old_name) = {
+            let Some(meta) = self.snapshot.file_table.get(file_id) else {
+                return;
+            };
+            let old_name = self
+                .snapshot
+                .string_arena
+                .get(meta.name_offset, meta.name_len)
+                .unwrap_or("")
+                .to_string();
+            ((meta.dev, meta.ino), old_name)
         };
 
-        let inode_key = (meta.dev, meta.ino);
         if inode_key != (0, 0) && self.inode_to_id.get(&inode_key) == Some(&file_id) {
             self.inode_to_id.remove(&inode_key);
         }
 
-        let old_name = self
-            .snapshot
-            .string_arena
-            .get(meta.name_offset, meta.name_len)
-            .unwrap_or("");
-        self.snapshot.trigram_index.remove_text(file_id, old_name);
+        self.snapshot.trigram_index.remove_text(file_id, &old_name);
+        self.remove_name_mapping(file_id, &old_name);
+
+        let Some(meta) = self.snapshot.file_table.get_mut(file_id) else {
+            return;
+        };
 
         // Tombstone the entry (keeps IDs stable).
         meta.path_len = 0;
@@ -394,6 +602,8 @@ impl DaemonState {
             self.upsert_path(to);
             return;
         };
+        self.remove_path_order(file_id, from_str.as_ref());
+        self.remove_recent_order(file_id);
 
         if !self.should_index(to) {
             self.tombstone_file(file_id);
@@ -441,25 +651,35 @@ impl DaemonState {
             .filter(|&existing_id| existing_id != file_id)
         {
             let _ = self.remove_path_mapping(to_str.as_ref());
+            self.remove_path_order(overwritten_id, to_str.as_ref());
+            self.remove_recent_order(overwritten_id);
             self.tombstone_file(overwritten_id);
+        }
+
+        let (old_inode_key, old_name) = {
+            let Some(meta) = self.snapshot.file_table.get(file_id) else {
+                return;
+            };
+            let old_name = self
+                .snapshot
+                .string_arena
+                .get(meta.name_offset, meta.name_len)
+                .unwrap_or("")
+                .to_string();
+            ((meta.dev, meta.ino), old_name)
+        };
+
+        if old_name != name_str.as_ref() {
+            self.remove_name_mapping(file_id, &old_name);
+            self.snapshot.trigram_index.remove_text(file_id, &old_name);
+            self.snapshot.trigram_index.add(file_id, name_str.as_ref());
         }
 
         let Some(meta) = self.snapshot.file_table.get_mut(file_id) else {
             return;
         };
 
-        let old_inode_key = (meta.dev, meta.ino);
-
-        let old_name = self
-            .snapshot
-            .string_arena
-            .get(meta.name_offset, meta.name_len)
-            .unwrap_or("");
-
         if old_name != name_str.as_ref() {
-            self.snapshot.trigram_index.remove_text(file_id, old_name);
-            self.snapshot.trigram_index.add(file_id, name_str.as_ref());
-
             let (name_offset, name_len) = self.snapshot.string_arena.add(name_str.as_ref());
             meta.name_offset = name_offset;
             meta.name_len = name_len;
@@ -485,8 +705,38 @@ impl DaemonState {
         }
 
         self.insert_path_mapping(to_str.as_ref(), file_id);
+        self.insert_path_order(file_id);
+        if old_name != name_str.as_ref() {
+            self.insert_name_mapping(file_id);
+        }
+        self.insert_recent_order(file_id);
         self.last_updated = now_epoch_seconds();
     }
+}
+
+fn normalized_scope_parts(scope: &Path) -> Option<(String, String)> {
+    let scope = scope.to_str()?.trim_end_matches('/');
+    let scope = if scope.is_empty() {
+        "/".to_string()
+    } else {
+        scope.to_string()
+    };
+    let scope_child_prefix = if scope == "/" {
+        "/".to_string()
+    } else {
+        format!("{scope}/")
+    };
+    Some((scope, scope_child_prefix))
+}
+
+fn path_is_in_normalized_scope(path: &str, scope: &str, scope_child_prefix: &str) -> bool {
+    path == scope || path.starts_with(scope_child_prefix)
+}
+
+fn is_exact_basename_query(query: &str) -> bool {
+    !query.is_empty()
+        && query.bytes().any(|b| matches!(b, b'.' | b'-' | b'_'))
+        && !query.bytes().any(|b| matches!(b, b'/' | b'\\'))
 }
 
 fn now_epoch_seconds() -> i64 {
@@ -564,6 +814,50 @@ fn build_inode_map(snapshot: &IndexSnapshot) -> std::collections::HashMap<(u64, 
         map.insert((meta.dev, meta.ino), file_id);
     }
     map
+}
+
+fn build_path_order(snapshot: &IndexSnapshot) -> Vec<FileId> {
+    let mut ids: Vec<FileId> = snapshot
+        .file_table
+        .iter()
+        .filter_map(|(file_id, meta)| (meta.path_len > 0).then_some(file_id))
+        .collect();
+    ids.sort_unstable_by(|&a, &b| {
+        let a_path = snapshot_path_for_id(snapshot, a).unwrap_or("");
+        let b_path = snapshot_path_for_id(snapshot, b).unwrap_or("");
+        a_path.cmp(b_path).then_with(|| a.cmp(&b))
+    });
+    ids
+}
+
+fn build_name_map(snapshot: &IndexSnapshot) -> std::collections::HashMap<String, Vec<FileId>> {
+    let mut map = std::collections::HashMap::<String, Vec<FileId>>::new();
+    for (file_id, meta) in snapshot.file_table.iter() {
+        if meta.name_len == 0 || meta.path_len == 0 {
+            continue;
+        }
+        let Some(name) = snapshot.string_arena.get(meta.name_offset, meta.name_len) else {
+            continue;
+        };
+        map.entry(name.to_lowercase()).or_default().push(file_id);
+    }
+    map
+}
+
+fn build_recent_order(snapshot: &IndexSnapshot) -> Vec<FileId> {
+    let mut ids: Vec<FileId> = snapshot
+        .file_table
+        .iter()
+        .filter_map(|(file_id, meta)| (meta.path_len > 0 && meta.name_len > 0).then_some(file_id))
+        .collect();
+    ids.sort_unstable_by(|&a, &b| {
+        let a_meta = snapshot.file_table.get(a);
+        let b_meta = snapshot.file_table.get(b);
+        let a_mtime = a_meta.map(|m| m.mtime).unwrap_or_default();
+        let b_mtime = b_meta.map(|m| m.mtime).unwrap_or_default();
+        b_mtime.cmp(&a_mtime).then_with(|| a.cmp(&b))
+    });
+    ids
 }
 
 fn journal_len(path: &Path) -> u64 {
@@ -661,38 +955,37 @@ pub fn full_rebuild_from_disk(
         };
 
         info!("Starting full index rebuild from disk...");
-        let scanner = Scanner::new(config);
+        let scanner = Scanner::new(config.clone());
         let snapshot = scanner.scan()?;
         let files_indexed = snapshot.file_table.len();
 
-        // Finalize: swap snapshot, apply any watcher updates that happened during the scan,
-        // then persist a fresh snapshot and clear the journal.
-        {
-            let mut state = state.write().unwrap();
-            let _journal_guard = journal_lock.lock().unwrap();
-
-            state.snapshot = snapshot;
-            let (path_to_id, path_hash_collisions) =
-                build_path_map(&state.snapshot, &state.path_hasher);
-            state.path_to_id = path_to_id;
-            state.path_hash_collisions = path_hash_collisions;
-            state.inode_to_id = build_inode_map(&state.snapshot);
-            state.last_updated = now_epoch_seconds();
-
+        // Finalize without holding the shared state write lock for expensive work.
+        // Holding the journal lock blocks watcher writes, but search/status can keep
+        // reading the previous hot snapshot until the final pointer-sized swap.
+        let _journal_guard = journal_lock.lock().unwrap();
+        let applied_updates = {
+            let mut rebuilt =
+                DaemonState::new(config, index_file.clone(), journal_file.clone(), snapshot);
             let applied_updates = apply_journal_from_offset(&journal_file, journal_offset, |u| {
-                state.apply_update(u);
+                rebuilt.apply_update(u);
             });
             if applied_updates > 0 {
                 debug!("Applied {} journal updates after rebuild", applied_updates);
             }
 
-            state.snapshot.save(&index_file)?;
+            rebuilt.snapshot.save(&index_file)?;
             truncate_journal(&journal_file)?;
+            rebuilt.reconciling = false;
 
-            state.reconciling = false;
-        }
+            let mut state = state.write().unwrap();
+            *state = rebuilt;
+            applied_updates
+        };
 
         info!("Full rebuild complete: {} files indexed", files_indexed);
+        if applied_updates > 0 {
+            debug!("Full rebuild included {} journal updates", applied_updates);
+        }
 
         Ok(files_indexed)
     })();
@@ -708,6 +1001,12 @@ pub fn full_rebuild_from_disk(
 /// IPC server that handles client connections.
 pub struct IpcServer {
     listener: UnixListener,
+    handler: IpcHandler,
+    socket_path: PathBuf,
+}
+
+#[derive(Clone)]
+struct IpcHandler {
     state: SharedState,
     shutdown: Arc<AtomicBool>,
     socket_path: PathBuf,
@@ -750,33 +1049,34 @@ impl IpcServer {
         listener
             .set_nonblocking(true)
             .map_err(|e| vicaya_core::Error::Ipc(format!("Failed to set nonblocking: {}", e)))?;
-
         info!("IPC server listening on {}", socket_path.display());
 
         Ok(Self {
             listener,
-            state,
-            shutdown,
             socket_path: socket_path.to_path_buf(),
-            journal_lock,
-            rebuild_lock,
+            handler: IpcHandler {
+                state,
+                shutdown,
+                socket_path: socket_path.to_path_buf(),
+                journal_lock,
+                rebuild_lock,
+            },
         })
     }
 
     /// Run the server loop.
     pub fn run(&self) -> Result<()> {
-        while !self.shutdown.load(Ordering::Relaxed) {
+        while !self.handler.shutdown.load(Ordering::Relaxed) {
             match self.listener.accept() {
                 Ok((stream, _addr)) => {
-                    // The listener is non-blocking, but client streams should be blocking so we can
-                    // read full newline-delimited requests and write full JSON responses.
                     if let Err(e) = stream.set_nonblocking(false) {
                         error!("Failed to set client stream blocking mode: {}", e);
                     }
-                    self.handle_client(stream);
+                    let handler = self.handler.clone();
+                    std::thread::spawn(move || handler.handle_client(stream));
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    std::thread::sleep(std::time::Duration::from_millis(25));
+                    std::thread::sleep(std::time::Duration::from_millis(1));
                 }
                 Err(e) => {
                     error!("Failed to accept connection: {}", e);
@@ -787,38 +1087,51 @@ impl IpcServer {
 
         Ok(())
     }
+}
 
+impl IpcHandler {
     /// Handle a single client connection.
     fn handle_client(&self, mut stream: UnixStream) {
         let peer_addr = stream.peer_addr().ok();
         debug!("Client connected: {:?}", peer_addr);
 
         let mut reader = BufReader::new(stream.try_clone().unwrap());
-        match vicaya_core::ipc::read_message(&mut reader) {
-            Ok(None) => debug!("Client disconnected"),
-            Ok(Some(line)) => {
-                let request = match Request::from_json(&line) {
-                    Ok(req) => req,
-                    Err(e) => {
-                        error!("Failed to parse request: {}", e);
-                        let response = Response::Error {
-                            message: format!("Invalid request: {}", e),
-                        };
-                        self.send_response(&mut stream, &response);
+
+        loop {
+            match vicaya_core::ipc::read_message(&mut reader) {
+                Ok(None) => {
+                    debug!("Client disconnected");
+                    return;
+                }
+                Ok(Some(line)) => {
+                    let request = match Request::from_json(&line) {
+                        Ok(req) => req,
+                        Err(e) => {
+                            error!("Failed to parse request: {}", e);
+                            let response = Response::Error {
+                                message: format!("Invalid request: {}", e),
+                            };
+                            self.send_response(&mut stream, &response);
+                            return;
+                        }
+                    };
+
+                    debug!("Received request: {:?}", request);
+                    let response = self.handle_request(request);
+                    self.send_response(&mut stream, &response);
+
+                    if self.shutdown.load(Ordering::Relaxed) {
                         return;
                     }
-                };
-
-                debug!("Received request: {:?}", request);
-                let response = self.handle_request(request);
-                self.send_response(&mut stream, &response);
-            }
-            Err(e) => {
-                error!("Failed to read from client: {}", e);
-                let response = Response::Error {
-                    message: e.to_string(),
-                };
-                self.send_response(&mut stream, &response);
+                }
+                Err(e) => {
+                    error!("Failed to read from client: {}", e);
+                    let response = Response::Error {
+                        message: e.to_string(),
+                    };
+                    self.send_response(&mut stream, &response);
+                    return;
+                }
             }
         }
     }
@@ -846,10 +1159,43 @@ impl IpcServer {
                 let filter_scope_path = filter_scope
                     .filter(|s| !s.trim().is_empty())
                     .map(std::path::PathBuf::from);
+                const SCOPED_LINEAR_SEARCH_LIMIT: usize = 100_000;
+                let scoped_file_ids = filter_scope_path.as_deref().and_then(|scope| {
+                    state.scoped_file_ids_up_to(scope, SCOPED_LINEAR_SEARCH_LIMIT)
+                });
+                let exact_name_file_ids = state.exact_name_file_ids(&query).map(|ids| {
+                    if let Some(scope) = filter_scope_path.as_deref() {
+                        state
+                            .filter_file_ids_in_scope(&ids, scope)
+                            .unwrap_or_default()
+                    } else {
+                        ids
+                    }
+                });
 
                 // If query is empty and recent_if_empty is true, return recent files
                 let results = if query.trim().is_empty() && recent_if_empty {
-                    engine.recent_files(limit, filter_scope_path.as_deref())
+                    if let Some((file_ids, true)) = scoped_file_ids.as_ref() {
+                        engine.recent_file_ids(limit, file_ids)
+                    } else if let Some(scope) = filter_scope_path.as_deref() {
+                        let file_ids = state
+                            .recent_file_ids_in_scope(limit, scope)
+                            .unwrap_or_default();
+                        engine.recent_file_ids(limit, &file_ids)
+                    } else {
+                        let end = state.recent_order.len().min(limit);
+                        engine.recent_file_ids(limit, &state.recent_order[..end])
+                    }
+                } else if let Some(file_ids) = exact_name_file_ids.as_deref() {
+                    engine.exact_name_file_ids(limit, file_ids)
+                } else if let Some((file_ids, true)) = scoped_file_ids.as_ref() {
+                    let query_obj = Query {
+                        term: query,
+                        limit,
+                        scope: scope_path,
+                        filter_scope: filter_scope_path,
+                    };
+                    engine.search_file_ids(&query_obj, file_ids)
                 } else {
                     let query_obj = Query {
                         term: query,
@@ -922,6 +1268,7 @@ impl IpcServer {
             Request::Shutdown => {
                 info!("Shutdown requested");
                 self.shutdown.store(true, Ordering::Relaxed);
+                let _ = UnixStream::connect(&self.socket_path);
                 Response::Ok
             }
         }
@@ -941,6 +1288,13 @@ impl IpcServer {
                 error!("Failed to serialize response: {}", e);
             }
         }
+    }
+}
+
+impl IpcServer {
+    #[cfg(test)]
+    fn handle_request(&self, request: Request) -> Response {
+        self.handler.handle_request(request)
     }
 }
 
@@ -1227,6 +1581,125 @@ mod tests {
             server.handle_request(Request::Shutdown),
             Response::Ok
         ));
+        assert!(shutdown.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn scoped_file_ids_up_to_reports_incomplete_large_scope() {
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        std::fs::write(root.path().join("a.txt"), "a").unwrap();
+        std::fs::write(root.path().join("b.txt"), "b").unwrap();
+        std::fs::write(root.path().join("c.txt"), "c").unwrap();
+
+        let state = build_state(root.path(), vicaya_dir.path());
+        let (ids, complete) = state.scoped_file_ids_up_to(root.path(), 1).unwrap();
+
+        assert!(!complete);
+        assert_eq!(ids.len(), 2);
+    }
+
+    #[test]
+    fn exact_name_search_is_filtered_inside_scope() {
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let inside_dir = root.path().join("inside");
+        let outside_dir = root.path().join("outside");
+        std::fs::create_dir_all(&inside_dir).unwrap();
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        let inside = inside_dir.join("main.go");
+        let outside = outside_dir.join("main.go");
+        std::fs::write(&inside, "package main\n").unwrap();
+        std::fs::write(&outside, "package main\n").unwrap();
+
+        let state = Arc::new(RwLock::new(build_state(root.path(), vicaya_dir.path())));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let journal_lock = Arc::new(Mutex::new(()));
+        let rebuild_lock = Arc::new(Mutex::new(()));
+        let socket = vicaya_dir.path().join("daemon.sock");
+        let server = IpcServer::new(&socket, state, shutdown, journal_lock, rebuild_lock).unwrap();
+
+        match server.handle_request(Request::Search {
+            query: "main.go".to_string(),
+            limit: 10,
+            scope: Some(inside_dir.to_string_lossy().to_string()),
+            filter_scope: Some(inside_dir.to_string_lossy().to_string()),
+            recent_if_empty: false,
+        }) {
+            Response::SearchResults { results } => {
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].path, inside.to_string_lossy());
+            }
+            other => panic!("unexpected exact scoped search response: {other:?}"),
+        }
+
+        assert!(outside.exists());
+    }
+
+    #[test]
+    fn ipc_server_accepts_persistent_client_requests() {
+        use std::io::Write as _;
+        use std::os::unix::net::UnixStream;
+
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cargo = root.path().join("Cargo.toml");
+        std::fs::write(&cargo, "[package]\n").unwrap();
+
+        let state = Arc::new(RwLock::new(build_state(root.path(), vicaya_dir.path())));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let journal_lock = Arc::new(Mutex::new(()));
+        let rebuild_lock = Arc::new(Mutex::new(()));
+        let socket = vicaya_dir.path().join("daemon.sock");
+        let server =
+            IpcServer::new(&socket, state, shutdown.clone(), journal_lock, rebuild_lock).unwrap();
+        let server_thread = std::thread::spawn(move || server.run().unwrap());
+
+        let mut stream = UnixStream::connect(&socket).unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+
+        let send = |stream: &mut UnixStream, request: Request| {
+            let mut json = request.to_json().unwrap();
+            json.push('\n');
+            stream.write_all(json.as_bytes()).unwrap();
+        };
+
+        send(&mut stream, Request::Status);
+        let line = vicaya_core::ipc::read_message(&mut reader)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            Response::from_json(&line).unwrap(),
+            Response::Status { .. }
+        ));
+
+        send(
+            &mut stream,
+            Request::Search {
+                query: "Cargo".to_string(),
+                limit: 10,
+                scope: Some(root.path().to_string_lossy().to_string()),
+                filter_scope: Some(root.path().to_string_lossy().to_string()),
+                recent_if_empty: false,
+            },
+        );
+        let line = vicaya_core::ipc::read_message(&mut reader)
+            .unwrap()
+            .unwrap();
+        match Response::from_json(&line).unwrap() {
+            Response::SearchResults { results } => assert_eq!(results.len(), 1),
+            other => panic!("unexpected persistent search response: {other:?}"),
+        }
+
+        send(&mut stream, Request::Shutdown);
+        let line = vicaya_core::ipc::read_message(&mut reader)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(Response::from_json(&line).unwrap(), Response::Ok));
+
+        drop(reader);
+        drop(stream);
+        server_thread.join().unwrap();
         assert!(shutdown.load(Ordering::Relaxed));
     }
 }

--- a/crates/vicaya-daemon/src/main.rs
+++ b/crates/vicaya-daemon/src/main.rs
@@ -8,9 +8,13 @@ use std::sync::{Arc, Mutex, RwLock};
 use tracing::{info, warn};
 use vicaya_core::{Config, Result};
 use vicaya_scanner::{IndexSnapshot, Scanner};
-use vicaya_watcher::FileWatcher;
+use vicaya_watcher::{FileWatcher, IndexUpdate};
 
-use crate::ipc_server::{DaemonState, IpcServer, SharedState};
+use crate::ipc_server::{
+    prepare_index_update, DaemonState, IpcServer, PreparedIndexUpdate, SharedState,
+};
+
+const WATCHER_APPLY_CHUNK_SIZE: usize = 256;
 
 fn main() -> Result<()> {
     vicaya_core::logging::init();
@@ -177,16 +181,53 @@ fn start_watcher_thread(
                 }
             }
 
-            let mut state = state.write().unwrap();
-            for update in updates {
-                state.apply_update(update);
-            }
+            apply_watcher_updates(&state, updates);
         }
 
         info!("Watcher thread exiting");
     });
 
     Ok(handle)
+}
+
+fn apply_watcher_updates(state: &SharedState, updates: Vec<IndexUpdate>) {
+    let config = { state.read().unwrap().config.clone() };
+    let updates = prepare_watcher_updates(&config, updates);
+    apply_watcher_updates_chunked(state, updates, WATCHER_APPLY_CHUNK_SIZE, |_| {
+        std::thread::yield_now();
+    });
+}
+
+fn prepare_watcher_updates(config: &Config, updates: Vec<IndexUpdate>) -> Vec<PreparedIndexUpdate> {
+    updates
+        .into_iter()
+        .map(|update| prepare_index_update(config, update))
+        .collect()
+}
+
+fn apply_watcher_updates_chunked<F>(
+    state: &SharedState,
+    updates: Vec<PreparedIndexUpdate>,
+    chunk_size: usize,
+    mut after_chunk: F,
+) where
+    F: FnMut(usize),
+{
+    let chunk_size = chunk_size.max(1);
+    let chunk_count = updates.len().div_ceil(chunk_size);
+
+    for (idx, chunk) in updates.chunks(chunk_size).enumerate() {
+        {
+            let mut state = state.write().unwrap();
+            for update in chunk {
+                state.apply_prepared_update(update.clone());
+            }
+        }
+
+        if idx + 1 < chunk_count {
+            after_chunk(idx + 1);
+        }
+    }
 }
 
 fn start_reconcile_thread(
@@ -315,5 +356,146 @@ fn is_internal_update(
             is_internal_path(from, internal_dir, index_dir)
                 || is_internal_path(to, internal_dir, index_dir)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use vicaya_core::config::PerformanceConfig;
+
+    fn test_config(root: &Path, vicaya_dir: &Path) -> Config {
+        Config {
+            index_roots: vec![root.to_path_buf()],
+            exclusions: vec![],
+            index_path: vicaya_dir.join("index"),
+            max_memory_mb: 128,
+            performance: PerformanceConfig {
+                scanner_threads: 2,
+                reconcile_hour: 3,
+            },
+        }
+    }
+
+    fn build_state(root: &Path, vicaya_dir: &Path) -> SharedState {
+        let config = test_config(root, vicaya_dir);
+        std::fs::create_dir_all(&config.index_path).unwrap();
+        let snapshot = Scanner::new(config.clone()).scan().unwrap();
+        Arc::new(RwLock::new(DaemonState::new(
+            config,
+            vicaya_dir.join("index.bin"),
+            vicaya_dir.join("journal.log"),
+            snapshot,
+        )))
+    }
+
+    fn state_contains_path(state: &DaemonState, path: &Path) -> bool {
+        let needle = path.to_string_lossy();
+        state.snapshot.file_table.iter().any(|(_, meta)| {
+            if meta.path_len == 0 {
+                return false;
+            }
+
+            state
+                .snapshot
+                .string_arena
+                .get(meta.path_offset, meta.path_len)
+                .is_some_and(|indexed| indexed == needle)
+        })
+    }
+
+    fn public_indexed_count(state: &DaemonState) -> usize {
+        state.path_to_id.len()
+            + state
+                .path_hash_collisions
+                .values()
+                .map(|ids| ids.len())
+                .sum::<usize>()
+    }
+
+    #[test]
+    fn watcher_updates_release_state_lock_between_chunks() {
+        let vicaya_dir = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let state = build_state(root.path(), vicaya_dir.path());
+
+        let first = root.path().join("one.txt");
+        let second = root.path().join("two.txt");
+        std::fs::write(&first, "one").unwrap();
+        std::fs::write(&second, "two").unwrap();
+
+        let updates = prepare_watcher_updates(
+            &state.read().unwrap().config,
+            vec![
+                IndexUpdate::Create {
+                    path: first.to_string_lossy().to_string(),
+                },
+                IndexUpdate::Create {
+                    path: second.to_string_lossy().to_string(),
+                },
+            ],
+        );
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+        let worker_state = Arc::clone(&state);
+
+        let worker = std::thread::spawn(move || {
+            apply_watcher_updates_chunked(&worker_state, updates, 1, |chunk| {
+                if chunk == 1 {
+                    ready_tx.send(()).unwrap();
+                    resume_rx.recv().unwrap();
+                }
+            });
+        });
+
+        ready_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        {
+            let state = state.read().unwrap();
+            assert!(public_indexed_count(&state) >= 1);
+        }
+        resume_tx.send(()).unwrap();
+        worker.join().unwrap();
+
+        let state = state.read().unwrap();
+        assert!(state_contains_path(&state, &first));
+        assert!(state_contains_path(&state, &second));
+    }
+
+    #[test]
+    fn internal_update_filter_rejects_vicaya_state_paths() {
+        let internal_dir = Path::new("/tmp/vicaya");
+        let index_dir = Path::new("/tmp/vicaya/index");
+        let indexed_path = "/tmp/repo/src/main.rs".to_string();
+        let internal_path = "/tmp/vicaya/daemon.sock".to_string();
+        let index_path = "/tmp/vicaya/index/index.journal".to_string();
+
+        assert!(!is_internal_update(
+            &IndexUpdate::Modify { path: indexed_path },
+            internal_dir,
+            index_dir
+        ));
+        assert!(is_internal_update(
+            &IndexUpdate::Modify {
+                path: internal_path
+            },
+            internal_dir,
+            index_dir
+        ));
+        assert!(is_internal_update(
+            &IndexUpdate::Create { path: index_path },
+            internal_dir,
+            index_dir
+        ));
+        assert!(is_internal_update(
+            &IndexUpdate::Move {
+                from: "/tmp/repo/a".to_string(),
+                to: "/tmp/vicaya/index/index.bin".to_string(),
+            },
+            internal_dir,
+            index_dir
+        ));
     }
 }

--- a/crates/vicaya-daemon/src/main.rs
+++ b/crates/vicaya-daemon/src/main.rs
@@ -266,7 +266,7 @@ fn start_reconcile_thread(
                 if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
                     return;
                 }
-                let step = std::cmp::min(std::time::Duration::from_secs(5), sleep_for - slept);
+                let step = std::cmp::min(std::time::Duration::from_millis(250), sleep_for - slept);
                 std::thread::sleep(step);
                 slept += step;
             }

--- a/crates/vicaya-daemon/src/main.rs
+++ b/crates/vicaya-daemon/src/main.rs
@@ -2,7 +2,6 @@
 
 mod ipc_server;
 
-use std::io::BufRead;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, RwLock};
@@ -55,11 +54,10 @@ fn main() -> Result<()> {
         snapshot,
     )));
 
-    // Fresh scans are authoritative. Only replay downtime journal entries when we had an
-    // existing on-disk snapshot to reconcile against.
-    if had_index {
-        replay_journal(&state, &journal_file)?;
-    } else {
+    // Fresh scans are authoritative. Existing snapshots become live immediately;
+    // startup reconcile catches downtime changes and truncates any stale journal
+    // after the IPC socket is ready.
+    if !had_index {
         clear_stale_journal(&journal_file)?;
     }
 
@@ -129,49 +127,6 @@ fn load_config() -> Result<Config> {
         config.save(&config_path)?;
         Ok(config)
     }
-}
-
-fn replay_journal(state: &SharedState, journal_file: &Path) -> Result<()> {
-    if !journal_file.exists() {
-        return Ok(());
-    }
-
-    let file = std::fs::File::open(journal_file)?;
-    let mut reader = std::io::BufReader::new(file);
-
-    let mut applied = 0usize;
-    let mut line = String::new();
-
-    let mut state = state.write().unwrap();
-    loop {
-        line.clear();
-        match reader.read_line(&mut line) {
-            Ok(0) => break,
-            Ok(_) => {}
-            Err(e) => {
-                warn!("Failed to read journal line: {}", e);
-                continue;
-            }
-        }
-
-        let trimmed = line.trim_end();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        match serde_json::from_str::<vicaya_watcher::IndexUpdate>(trimmed) {
-            Ok(update) => {
-                state.apply_update(update);
-                applied += 1;
-            }
-            Err(e) => warn!("Skipping invalid journal entry: {}", e),
-        }
-    }
-
-    if applied > 0 {
-        info!("Replayed {} journal updates", applied);
-    }
-    Ok(())
 }
 
 fn clear_stale_journal(journal_file: &Path) -> Result<()> {

--- a/crates/vicaya-daemon/tests/startup_reconcile.rs
+++ b/crates/vicaya-daemon/tests/startup_reconcile.rs
@@ -194,22 +194,30 @@ fn it_replays_journal_when_starting_from_existing_index() {
     let socket = vicaya_dir.path().join("daemon.sock");
     wait_for_socket(&socket, Duration::from_secs(10));
 
-    let response = ipc_request(
-        &socket,
-        &Request::Search {
-            query: "after.txt".to_string(),
-            limit: 20,
-            scope: None,
-            filter_scope: None,
-            recent_if_empty: false,
-        },
-    );
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let response = ipc_request(
+            &socket,
+            &Request::Search {
+                query: "after.txt".to_string(),
+                limit: 20,
+                scope: None,
+                filter_scope: None,
+                recent_if_empty: false,
+            },
+        );
 
-    match response {
-        Response::SearchResults { results } => {
-            assert!(results.iter().any(|r| r.path.ends_with("after.txt")));
+        if let Response::SearchResults { results } = response {
+            if results.iter().any(|r| r.path.ends_with("after.txt")) {
+                break;
+            }
         }
-        other => panic!("unexpected response: {:?}", other),
+
+        if Instant::now() >= deadline {
+            panic!("Timed out waiting for startup reconcile to apply journal update");
+        }
+
+        std::thread::sleep(Duration::from_millis(50));
     }
 
     let _ = ipc_request(&socket, &Request::Shutdown);

--- a/crates/vicaya-index/src/abbreviation.rs
+++ b/crates/vicaya-index/src/abbreviation.rs
@@ -141,8 +141,9 @@ impl AbbreviationMatcher {
             .and_then(|s| s.to_str())
             .unwrap_or(&filename_lower);
 
+        let query_len = query.chars().count();
         if stem.starts_with(query) {
-            let matched_indices: Vec<usize> = (0..query.len()).collect();
+            let matched_indices: Vec<usize> = (0..query_len).collect();
             // Give perfect score for exact match, slightly lower for prefix
             let score = if stem == query { 1.0 } else { 0.99 };
             return Some(AbbreviationMatch {
@@ -156,7 +157,7 @@ impl AbbreviationMatcher {
         for component in Path::new(&path_lower).components() {
             if let Some(comp_str) = component.as_os_str().to_str() {
                 if comp_str.starts_with(query) {
-                    let matched_indices: Vec<usize> = (0..query.len()).collect();
+                    let matched_indices: Vec<usize> = (0..query_len).collect();
                     return Some(AbbreviationMatch {
                         score: 0.98, // Slightly lower than filename prefix
                         strategy: MatchStrategy::ExactPrefix,
@@ -209,7 +210,8 @@ impl AbbreviationMatcher {
         if query_idx == query_chars.len() {
             // Calculate score based on match quality
             let base_score = 0.95;
-            let consecutive_bonus = self.calculate_consecutive_bonus(&matched_indices, query.len());
+            let consecutive_bonus =
+                self.calculate_consecutive_bonus(&matched_indices, query_chars.len());
             let coverage_ratio = matched_indices.len() as f32 / first_letters.len() as f32;
             let coverage_bonus = coverage_ratio * 0.05;
 
@@ -279,7 +281,7 @@ impl AbbreviationMatcher {
         if query_idx == query_chars.len() {
             let base_score = 0.90;
             let consecutive_bonus =
-                self.calculate_consecutive_bonus(&matched_indices, query_lower.len());
+                self.calculate_consecutive_bonus(&matched_indices, query_chars.len());
 
             // Bonus for matching actual uppercase in query to uppercase in path
             let case_match_bonus =
@@ -340,7 +342,8 @@ impl AbbreviationMatcher {
             let base_score = 0.70;
 
             // Bonus for consecutive matches
-            let consecutive_bonus = self.calculate_consecutive_bonus(&matched_indices, query.len());
+            let consecutive_bonus =
+                self.calculate_consecutive_bonus(&matched_indices, query_chars.len());
 
             // Bonus for matches closer to end (filename)
             let avg_pos =
@@ -350,7 +353,7 @@ impl AbbreviationMatcher {
 
             // Penalty for large gaps
             let total_span = matched_indices.last().unwrap() - matched_indices.first().unwrap() + 1;
-            let gap_ratio = (total_span - query.len()) as f32 / path_chars.len() as f32;
+            let gap_ratio = (total_span - query_chars.len()) as f32 / path_chars.len() as f32;
             let gap_penalty = gap_ratio * 0.10;
 
             let score =

--- a/crates/vicaya-index/src/file_table.rs
+++ b/crates/vicaya-index/src/file_table.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Uses u32 to support up to 4.2 billion files while minimizing memory usage.
 /// This is more than sufficient for any single-machine filesystem indexer.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct FileId(pub u32);
 
 /// Metadata for a single file entry.

--- a/crates/vicaya-index/src/query.rs
+++ b/crates/vicaya-index/src/query.rs
@@ -599,10 +599,16 @@ impl<'a> QueryEngine<'a> {
 }
 
 fn lower_if_needed(text: &str) -> std::borrow::Cow<'_, str> {
-    if text.bytes().all(|b| !b.is_ascii_uppercase()) {
-        std::borrow::Cow::Borrowed(text)
-    } else {
+    if text.is_ascii() {
+        if text.bytes().any(|b| b.is_ascii_uppercase()) {
+            std::borrow::Cow::Owned(text.to_lowercase())
+        } else {
+            std::borrow::Cow::Borrowed(text)
+        }
+    } else if text.chars().any(|c| c.is_uppercase()) {
         std::borrow::Cow::Owned(text.to_lowercase())
+    } else {
+        std::borrow::Cow::Borrowed(text)
     }
 }
 
@@ -676,6 +682,38 @@ mod tests {
         let results = engine.search(&query);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "test.txt");
+    }
+
+    #[test]
+    fn unicode_uppercase_filename_matches_lowercase_query() {
+        let mut file_table = FileTable::new();
+        let mut arena = StringArena::new();
+        let mut index = TrigramIndex::new();
+
+        let (path_off, path_len) = arena.add("/repo/Überblick.md");
+        let (name_off, name_len) = arena.add("Überblick.md");
+        let file_id = file_table.insert(FileMeta {
+            path_offset: path_off,
+            path_len,
+            name_offset: name_off,
+            name_len,
+            size: 1,
+            mtime: 0,
+            dev: 0,
+            ino: 0,
+        });
+        index.add(file_id, "Überblick.md");
+
+        let engine = QueryEngine::new(&file_table, &arena, &index);
+        let results = engine.search(&Query {
+            term: "über".to_string(),
+            limit: 10,
+            scope: None,
+            filter_scope: None,
+        });
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Überblick.md");
     }
 
     #[test]

--- a/crates/vicaya-index/src/query.rs
+++ b/crates/vicaya-index/src/query.rs
@@ -2,7 +2,8 @@
 
 use crate::{AbbreviationMatcher, FileId, FileTable, StringArena, Trigram, TrigramIndex};
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
+use std::collections::BinaryHeap;
 use std::path::{Path, PathBuf};
 
 /// A search query.
@@ -77,19 +78,37 @@ impl<'a> QueryEngine<'a> {
         let trigrams = Trigram::extract(&normalized);
         let candidates = self.trigram_index.query(&trigrams);
 
-        // Score and filter candidates
-        let mut ranked: Vec<(SearchResult, RankFeatures)> = candidates
-            .iter()
-            .filter_map(|&file_id| {
+        let mut ranked: Vec<(SearchResult, RankFeatures)> = Vec::with_capacity(query.limit);
+        for file_id in candidates {
+            if let Some(result) =
                 self.score_candidate(file_id, &normalized, boost_scope, filter_scope, cwd)
-            })
-            .collect();
-
+            {
+                self.push_ranked_candidate(&mut ranked, result, query.limit);
+            }
+        }
         self.sort_ranked_results(&mut ranked);
-
-        // Limit results
-        ranked.truncate(query.limit);
         ranked.into_iter().map(|(r, _)| r).collect()
+    }
+
+    /// Execute a query against a pre-filtered set of file IDs.
+    ///
+    /// This is intended for daemon-side scope accelerators where enumerating a small
+    /// subtree is cheaper than probing global posting lists and filtering afterward.
+    pub fn search_file_ids(&self, query: &Query, file_ids: &[FileId]) -> Vec<SearchResult> {
+        let normalized = query.term.to_lowercase();
+        let boost_scope = query.scope.as_deref();
+        let filter_scope = query.filter_scope.as_deref();
+        let cwd = std::env::current_dir().ok();
+        let cwd = cwd.as_deref();
+
+        self.search_file_ids_normalized(
+            &normalized,
+            boost_scope,
+            filter_scope,
+            cwd,
+            query.limit,
+            file_ids,
+        )
     }
 
     /// Score a candidate file.
@@ -113,23 +132,24 @@ impl<'a> QueryEngine<'a> {
             }
         }
 
-        // Check if the query matches the basename or path
-        let name_lower = name.to_lowercase();
-        let path_lower = path.to_lowercase();
-
-        // Try abbreviation matching first (especially for short queries)
-        let abbr_matcher = AbbreviationMatcher::new();
-        let abbr_score = if let Some(abbr_match) = abbr_matcher.match_path(query, path) {
-            Some(abbr_match.score)
-        } else {
-            None
-        };
+        let name_lower = lower_if_needed(name);
+        let path_lower = lower_if_needed(path);
 
         // Try traditional substring matching
-        let substring_score = if name_lower.contains(query) || path_lower.contains(query) {
-            Some(self.calculate_score(&name_lower, &path_lower, query))
-        } else {
+        let substring_score =
+            if name_lower.as_ref().contains(query) || path_lower.as_ref().contains(query) {
+                Some(self.calculate_score(name_lower.as_ref(), path_lower.as_ref(), query))
+            } else {
+                None
+            };
+
+        let abbr_score = if substring_score == Some(1.0) || is_literal_filename_query(query) {
             None
+        } else {
+            let abbr_matcher = AbbreviationMatcher::new();
+            abbr_matcher
+                .match_path(query, path)
+                .map(|abbr_match| abbr_match.score)
         };
 
         // Use the best score from either method
@@ -142,7 +162,7 @@ impl<'a> QueryEngine<'a> {
 
         let path_depth = Self::path_depth(path);
         let features = RankFeatures {
-            context_score: Self::context_score(&path_lower)
+            context_score: Self::context_score(path_lower.as_ref())
                 + Self::scope_boost(path_buf, boost_scope, cwd),
             path_depth,
         };
@@ -212,6 +232,32 @@ impl<'a> QueryEngine<'a> {
                 break;
             }
 
+            if let Some(result) =
+                self.score_candidate(file_id, query, boost_scope, filter_scope, cwd)
+            {
+                self.push_ranked_candidate(&mut ranked, result, limit);
+            }
+        }
+
+        self.sort_ranked_results(&mut ranked);
+        ranked.into_iter().map(|(r, _)| r).collect()
+    }
+
+    fn search_file_ids_normalized(
+        &self,
+        query: &str,
+        boost_scope: Option<&Path>,
+        filter_scope: Option<&Path>,
+        cwd: Option<&Path>,
+        limit: usize,
+        file_ids: &[FileId],
+    ) -> Vec<SearchResult> {
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        let mut ranked: Vec<(SearchResult, RankFeatures)> = Vec::with_capacity(limit);
+        for &file_id in file_ids {
             if let Some(result) =
                 self.score_candidate(file_id, query, boost_scope, filter_scope, cwd)
             {
@@ -359,51 +405,154 @@ impl<'a> QueryEngine<'a> {
     /// Returns the N most recently modified files, optionally filtered by scope.
     /// Used for populating TUI on startup when no query is provided.
     pub fn recent_files(&self, limit: usize, filter_scope: Option<&Path>) -> Vec<SearchResult> {
+        if limit == 0 {
+            return Vec::new();
+        }
+
         let cwd = std::env::current_dir().ok();
         let cwd = cwd.as_deref();
 
-        // Collect entries with their mtime for sorting
-        let mut entries: Vec<(i64, SearchResult)> = self
-            .file_table
-            .iter()
-            .filter_map(|(_file_id, meta)| {
+        let mut heap: BinaryHeap<Reverse<RecentCandidate>> = BinaryHeap::with_capacity(limit + 1);
+
+        for (file_id, meta) in self.file_table.iter() {
+            let Some(path) = self.string_arena.get(meta.path_offset, meta.path_len) else {
+                continue;
+            };
+            let Some(name) = self.string_arena.get(meta.name_offset, meta.name_len) else {
+                continue;
+            };
+
+            // Skip tombstones and entries with empty names (e.g., root directories).
+            if name.is_empty() {
+                continue;
+            }
+
+            if let Some(scope_path) = filter_scope {
+                if !Self::scope_contains(Path::new(path), scope_path, cwd) {
+                    continue;
+                }
+            }
+
+            heap.push(Reverse(RecentCandidate {
+                mtime: meta.mtime,
+                file_id,
+            }));
+            if heap.len() > limit {
+                heap.pop();
+            }
+        }
+
+        let mut candidates: Vec<RecentCandidate> = heap
+            .into_iter()
+            .map(|Reverse(candidate)| candidate)
+            .collect();
+        candidates.sort_by(|a, b| {
+            b.mtime
+                .cmp(&a.mtime)
+                .then_with(|| a.file_id.cmp(&b.file_id))
+        });
+
+        candidates
+            .into_iter()
+            .filter_map(|candidate| {
+                let meta = self.file_table.get(candidate.file_id)?;
                 let path = self.string_arena.get(meta.path_offset, meta.path_len)?;
                 let name = self.string_arena.get(meta.name_offset, meta.name_len)?;
+                Some(SearchResult {
+                    path: path.to_string(),
+                    name: name.to_string(),
+                    score: 0.0,
+                    size: meta.size,
+                    mtime: meta.mtime,
+                })
+            })
+            .collect()
+    }
 
-                // Skip entries with empty names (e.g., root directories)
+    /// Returns the N most recently modified files from a pre-filtered set of file IDs.
+    pub fn recent_file_ids(&self, limit: usize, file_ids: &[FileId]) -> Vec<SearchResult> {
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        let mut heap: BinaryHeap<Reverse<RecentCandidate>> = BinaryHeap::with_capacity(limit + 1);
+
+        for &file_id in file_ids {
+            let Some(meta) = self.file_table.get(file_id) else {
+                continue;
+            };
+            let Some(name) = self.string_arena.get(meta.name_offset, meta.name_len) else {
+                continue;
+            };
+            if name.is_empty() {
+                continue;
+            }
+
+            heap.push(Reverse(RecentCandidate {
+                mtime: meta.mtime,
+                file_id,
+            }));
+            if heap.len() > limit {
+                heap.pop();
+            }
+        }
+
+        let mut candidates: Vec<RecentCandidate> = heap
+            .into_iter()
+            .map(|Reverse(candidate)| candidate)
+            .collect();
+        candidates.sort_by(|a, b| {
+            b.mtime
+                .cmp(&a.mtime)
+                .then_with(|| a.file_id.cmp(&b.file_id))
+        });
+
+        candidates
+            .into_iter()
+            .filter_map(|candidate| {
+                let meta = self.file_table.get(candidate.file_id)?;
+                let path = self.string_arena.get(meta.path_offset, meta.path_len)?;
+                let name = self.string_arena.get(meta.name_offset, meta.name_len)?;
+                Some(SearchResult {
+                    path: path.to_string(),
+                    name: name.to_string(),
+                    score: 0.0,
+                    size: meta.size,
+                    mtime: meta.mtime,
+                })
+            })
+            .collect()
+    }
+
+    /// Returns exact-basename matches from a daemon-maintained name index.
+    pub fn exact_name_file_ids(&self, limit: usize, file_ids: &[FileId]) -> Vec<SearchResult> {
+        let mut results: Vec<SearchResult> = file_ids
+            .iter()
+            .filter_map(|&file_id| {
+                let meta = self.file_table.get(file_id)?;
+                let path = self.string_arena.get(meta.path_offset, meta.path_len)?;
+                let name = self.string_arena.get(meta.name_offset, meta.name_len)?;
                 if name.is_empty() {
                     return None;
                 }
-
-                // Filter by scope if provided
-                if let Some(scope_path) = filter_scope {
-                    if !Self::scope_contains(Path::new(path), scope_path, cwd) {
-                        return None;
-                    }
-                }
-
-                Some((
-                    meta.mtime,
-                    SearchResult {
-                        path: path.to_string(),
-                        name: name.to_string(),
-                        score: 0.0, // No query match, just recency
-                        size: meta.size,
-                        mtime: meta.mtime,
-                    },
-                ))
+                Some(SearchResult {
+                    path: path.to_string(),
+                    name: name.to_string(),
+                    score: 1.0,
+                    size: meta.size,
+                    mtime: meta.mtime,
+                })
             })
             .collect();
 
-        // Sort by mtime descending (most recent first)
-        entries.sort_by(|(mtime_a, _), (mtime_b, _)| mtime_b.cmp(mtime_a));
-
-        // Take top N
-        entries
-            .into_iter()
-            .take(limit)
-            .map(|(_, result)| result)
-            .collect()
+        results.sort_by(|a, b| {
+            b.mtime
+                .cmp(&a.mtime)
+                .then_with(|| path_depth_str(&a.path).cmp(&path_depth_str(&b.path)))
+                .then_with(|| a.path.cmp(&b.path))
+        });
+        results.truncate(limit);
+        results
     }
 
     fn scope_contains(path: &Path, scope: &Path, cwd: Option<&Path>) -> bool {
@@ -446,6 +595,44 @@ impl<'a> QueryEngine<'a> {
             }
         }
         normalized
+    }
+}
+
+fn lower_if_needed(text: &str) -> std::borrow::Cow<'_, str> {
+    if text.bytes().all(|b| !b.is_ascii_uppercase()) {
+        std::borrow::Cow::Borrowed(text)
+    } else {
+        std::borrow::Cow::Owned(text.to_lowercase())
+    }
+}
+
+fn is_literal_filename_query(query: &str) -> bool {
+    query
+        .bytes()
+        .any(|b| matches!(b, b'.' | b'-' | b'_' | b'/' | b'\\'))
+}
+
+fn path_depth_str(path: &str) -> usize {
+    std::path::Path::new(path).components().count()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RecentCandidate {
+    mtime: i64,
+    file_id: FileId,
+}
+
+impl Ord for RecentCandidate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.mtime
+            .cmp(&other.mtime)
+            .then_with(|| other.file_id.cmp(&self.file_id))
+    }
+}
+
+impl PartialOrd for RecentCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/vicaya-index/src/trigram.rs
+++ b/crates/vicaya-index/src/trigram.rs
@@ -52,7 +52,15 @@ impl TrigramIndex {
         unique_trigrams.dedup();
 
         for trigram in unique_trigrams {
-            self.index.entry(trigram).or_default().push(file_id);
+            let posting_list = self.index.entry(trigram).or_default();
+            if posting_list.last().is_some_and(|&last| last > file_id) {
+                match posting_list.binary_search(&file_id) {
+                    Ok(_) => {}
+                    Err(pos) => posting_list.insert(pos, file_id),
+                }
+            } else if posting_list.last() != Some(&file_id) {
+                posting_list.push(file_id);
+            }
         }
     }
 
@@ -94,26 +102,28 @@ impl TrigramIndex {
             return Vec::new();
         }
 
-        // Find the smallest posting list
-        let smallest = trigrams
-            .iter()
-            .filter_map(|t| self.index.get(t))
-            .min_by_key(|list| list.len());
+        let mut unique_trigrams = trigrams.to_vec();
+        unique_trigrams.sort_unstable();
+        unique_trigrams.dedup();
 
-        let Some(candidates) = smallest else {
+        let mut posting_lists: Vec<&Vec<FileId>> = Vec::with_capacity(unique_trigrams.len());
+        for trigram in &unique_trigrams {
+            let Some(list) = self.index.get(trigram) else {
+                return Vec::new();
+            };
+            posting_lists.push(list);
+        }
+        posting_lists.sort_unstable_by_key(|list| list.len());
+
+        let Some((smallest, rest)) = posting_lists.split_first() else {
             return Vec::new();
         };
 
-        // Filter candidates that contain all trigrams
-        candidates
+        // Filter candidates that contain all trigrams. Posting lists are kept sorted by FileId,
+        // so membership checks stay logarithmic even for very common filename trigrams.
+        smallest
             .iter()
-            .filter(|&&file_id| {
-                trigrams.iter().all(|t| {
-                    self.index
-                        .get(t)
-                        .is_some_and(|list| list.contains(&file_id))
-                })
-            })
+            .filter(|&&file_id| rest.iter().all(|list| list.binary_search(&file_id).is_ok()))
             .copied()
             .collect()
     }
@@ -167,5 +177,18 @@ mod tests {
         assert!(results.contains(&FileId(1)));
         assert!(results.contains(&FileId(3)));
         assert!(!results.contains(&FileId(2)));
+    }
+
+    #[test]
+    fn posting_lists_stay_sorted_when_updated_out_of_order() {
+        let mut index = TrigramIndex::new();
+
+        index.add(FileId(3), "hello");
+        index.add(FileId(1), "hello");
+        index.add(FileId(2), "hello");
+        index.add(FileId(2), "hello");
+
+        let results = index.query(&Trigram::extract("hel"));
+        assert_eq!(results, vec![FileId(1), FileId(2), FileId(3)]);
     }
 }

--- a/crates/vicaya-tui/src/client/mod.rs
+++ b/crates/vicaya-tui/src/client/mod.rs
@@ -2,25 +2,47 @@
 
 use std::io::{BufReader, Write};
 use std::os::unix::net::UnixStream;
+use std::time::Duration;
 use vicaya_core::ipc::{Request, Response};
 use vicaya_index::SearchResult;
+
+const IPC_TIMEOUT: Duration = Duration::from_secs(2);
+const REQUEST_ATTEMPTS: usize = 3;
 
 /// IPC client for daemon communication.
 pub struct IpcClient {
     stream: Option<UnixStream>,
+    timeout: Duration,
+    attempts: usize,
 }
 
 impl IpcClient {
     /// Create a new IPC client and attempt to connect.
     pub fn new() -> Self {
-        let stream = Self::try_connect();
-        Self { stream }
+        Self::with_options(IPC_TIMEOUT, REQUEST_ATTEMPTS)
+    }
+
+    /// Create a best-effort IPC client for background health checks.
+    pub fn best_effort() -> Self {
+        Self::with_options(Duration::from_secs(1), 1)
+    }
+
+    fn with_options(timeout: Duration, attempts: usize) -> Self {
+        let stream = Self::try_connect(timeout);
+        Self {
+            stream,
+            timeout,
+            attempts,
+        }
     }
 
     /// Try to connect to the daemon.
-    fn try_connect() -> Option<UnixStream> {
+    fn try_connect(timeout: Duration) -> Option<UnixStream> {
         let socket_path = vicaya_core::ipc::socket_path();
-        UnixStream::connect(&socket_path).ok()
+        let stream = UnixStream::connect(&socket_path).ok()?;
+        let _ = stream.set_read_timeout(Some(timeout));
+        let _ = stream.set_write_timeout(Some(timeout));
+        Some(stream)
     }
 
     /// Check if connected to daemon.
@@ -30,7 +52,7 @@ impl IpcClient {
 
     /// Reconnect to the daemon.
     pub fn reconnect(&mut self) {
-        self.stream = Self::try_connect();
+        self.stream = Self::try_connect(self.timeout);
     }
 
     /// Search for files.
@@ -117,39 +139,46 @@ impl IpcClient {
 
     /// Send a request and receive a response.
     fn request(&mut self, req: &Request) -> anyhow::Result<Response> {
-        // Try with existing connection first
-        let mut stream = if let Some(stream) = self.stream.as_mut() {
-            stream
-        } else {
-            // No connection, try to establish one
-            self.reconnect();
-            self.stream
-                .as_mut()
-                .ok_or_else(|| anyhow::anyhow!("Daemon not running"))?
-        };
-
-        // Serialize request
         let mut request_json = req
             .to_json()
             .map_err(|e| anyhow::anyhow!("Failed to serialize request: {}", e))?;
         request_json.push('\n');
 
-        // Try to send request
-        let result = stream.write_all(request_json.as_bytes());
+        let mut last_error: Option<anyhow::Error> = None;
 
-        // If write failed, try reconnecting once
-        if result.is_err() {
-            self.reconnect();
-            stream = self
-                .stream
-                .as_mut()
-                .ok_or_else(|| anyhow::anyhow!("Daemon not running"))?;
-            stream
-                .write_all(request_json.as_bytes())
-                .map_err(|e| anyhow::anyhow!("Failed to send request: {}", e))?;
+        for attempt in 0..self.attempts {
+            match self.request_once(&request_json) {
+                Ok(response) => return Ok(response),
+                Err(error) => {
+                    last_error = Some(error);
+                    self.stream = None;
+                }
+            }
+
+            if attempt + 1 < self.attempts {
+                std::thread::sleep(Duration::from_millis(50));
+                self.stream = None;
+                self.reconnect();
+            }
         }
 
-        // Read response
+        Err(last_error.unwrap_or_else(|| anyhow::anyhow!("Daemon not running")))
+    }
+
+    fn request_once(&mut self, request_json: &str) -> anyhow::Result<Response> {
+        if self.stream.is_none() {
+            self.reconnect();
+        }
+
+        let stream = self
+            .stream
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Daemon not running"))?;
+
+        stream
+            .write_all(request_json.as_bytes())
+            .map_err(|e| anyhow::anyhow!("Failed to send request: {}", e))?;
+
         let mut reader = BufReader::new(stream);
         let line = vicaya_core::ipc::read_message(&mut reader)?
             .ok_or_else(|| anyhow::anyhow!("Daemon closed IPC connection"))?;
@@ -200,6 +229,48 @@ mod tests {
             json.push('\n');
             stream.write_all(json.as_bytes()).unwrap();
             request
+        })
+    }
+
+    fn close_then_response_server(
+        dir: &std::path::Path,
+        response: Response,
+    ) -> std::thread::JoinHandle<Vec<Request>> {
+        close_n_then_response_server(dir, 1, response)
+    }
+
+    fn close_n_then_response_server(
+        dir: &std::path::Path,
+        close_count: usize,
+        response: Response,
+    ) -> std::thread::JoinHandle<Vec<Request>> {
+        let socket = dir.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        std::thread::spawn(move || {
+            let mut requests = Vec::new();
+
+            for _ in 0..close_count {
+                let (stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream);
+                let line = vicaya_core::ipc::read_message(&mut reader)
+                    .unwrap()
+                    .unwrap();
+                requests.push(Request::from_json(&line).unwrap());
+                drop(reader);
+            }
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let line = vicaya_core::ipc::read_message(&mut reader)
+                .unwrap()
+                .unwrap();
+            requests.push(Request::from_json(&line).unwrap());
+            let mut json = response.to_json().unwrap();
+            json.push('\n');
+            stream.write_all(json.as_bytes()).unwrap();
+
+            requests
         })
     }
 
@@ -263,7 +334,11 @@ mod tests {
 
     #[test]
     fn empty_non_recent_search_returns_without_ipc() {
-        let mut client = IpcClient { stream: None };
+        let _lock = vicaya_core::paths::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", dir.path());
+        let mut client = IpcClient::best_effort();
+        client.stream = None;
         let results = client.search("", 10, None, None, false).unwrap();
         assert!(results.is_empty());
     }
@@ -302,6 +377,65 @@ mod tests {
             handle.join().unwrap(),
             Request::Rebuild { dry_run: true }
         ));
+    }
+
+    #[test]
+    fn request_reconnects_when_daemon_closes_stale_stream() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", dir.path());
+        let handle = close_then_response_server(
+            dir.path(),
+            Response::Status {
+                pid: 99,
+                build: build_info(),
+                indexed_files: 42,
+                trigram_count: 777,
+                arena_size: 4096,
+                index_allocated_bytes: 8192,
+                state_allocated_bytes: 16384,
+                last_updated: 1_700_000_000,
+                reconciling: false,
+            },
+        );
+
+        let mut client = IpcClient::new();
+        let status = client.status().unwrap();
+        let requests = handle.join().unwrap();
+
+        assert_eq!(status.indexed_files, 42);
+        assert_eq!(requests.len(), 2);
+        assert!(requests.iter().all(|req| matches!(req, Request::Status)));
+    }
+
+    #[test]
+    fn request_survives_short_daemon_restart_window() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", dir.path());
+        let handle = close_n_then_response_server(
+            dir.path(),
+            2,
+            Response::SearchResults {
+                results: vec![vicaya_core::ipc::SearchResult {
+                    path: "/tmp/repo/main.rs".to_string(),
+                    name: "main.rs".to_string(),
+                    score: 1.0,
+                    size: 12,
+                    mtime: 1_700_000_000,
+                }],
+            },
+        );
+
+        let mut client = IpcClient::new();
+        let results = client.search("main", 10, None, None, false).unwrap();
+        let requests = handle.join().unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(requests.len(), 3);
+        assert!(requests
+            .iter()
+            .all(|req| matches!(req, Request::Search { query, .. } if query == "main")));
     }
 
     #[test]

--- a/crates/vicaya-tui/src/worker.rs
+++ b/crates/vicaya-tui/src/worker.rs
@@ -3,7 +3,7 @@
 use crate::client::{DaemonStatus, IpcClient};
 use crate::state::{Niyama, NiyamaType, StyledLine, StyledSegment, TextKind, TextStyle, ViewKind};
 use std::sync::mpsc::{Receiver, Sender};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use vicaya_index::SearchResult;
 
 use syntect::{
@@ -11,6 +11,18 @@ use syntect::{
     highlighting::{FontStyle, Theme, ThemeSet},
     parsing::SyntaxSet,
     util::LinesWithEndings,
+};
+
+const STATUS_FAILURES_BEFORE_OFFLINE: usize = 2;
+const STATUS_POLL_INTERVAL: Duration = if cfg!(test) {
+    Duration::from_millis(50)
+} else {
+    Duration::from_secs(2)
+};
+const STATUS_POLL_SLEEP_STEP: Duration = if cfg!(test) {
+    Duration::from_millis(10)
+} else {
+    Duration::from_millis(50)
 };
 
 pub enum WorkerCommand {
@@ -56,8 +68,9 @@ pub fn start_worker(
 }
 
 fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
-    let mut client = IpcClient::new();
-    let mut last_status_at = Instant::now() - Duration::from_secs(60);
+    let mut search_client = IpcClient::new();
+    let status_stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let status_handle = start_status_worker(evt_tx.clone(), status_stop.clone());
 
     let syntaxes = SyntaxSet::load_defaults_newlines();
     let themes = ThemeSet::load_defaults();
@@ -77,7 +90,7 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
     let mut pending_search: Option<PendingSearch> = None;
     let mut pending_preview: Option<(u64, String)> = None;
 
-    loop {
+    'worker: loop {
         // Receive at least one command, but wake periodically for status.
         match cmd_rx.recv_timeout(Duration::from_millis(100)) {
             Ok(cmd) => match cmd {
@@ -101,10 +114,10 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
                     })
                 }
                 WorkerCommand::Preview { id, path } => pending_preview = Some((id, path)),
-                WorkerCommand::Quit => break,
+                WorkerCommand::Quit => break 'worker,
             },
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break 'worker,
         }
 
         // Coalesce bursts: keep only the latest search/preview request.
@@ -130,15 +143,8 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
                     })
                 }
                 WorkerCommand::Preview { id, path } => pending_preview = Some((id, path)),
-                WorkerCommand::Quit => return,
+                WorkerCommand::Quit => break 'worker,
             }
-        }
-
-        // Periodic status updates (best-effort).
-        if last_status_at.elapsed() >= Duration::from_secs(2) {
-            let status = client.status().ok();
-            let _ = evt_tx.send(WorkerEvent::Status { status });
-            last_status_at = Instant::now();
         }
 
         if let Some(PendingSearch {
@@ -162,19 +168,24 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
             // When query is empty, request recent files from daemon
             let recent_if_empty = trimmed.is_empty();
 
-            let mut results =
-                match client.search(&trimmed, limit, boost_scope, filter_scope, recent_if_empty) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        client.reconnect();
-                        let _ = evt_tx.send(WorkerEvent::SearchResults {
-                            id,
-                            results: Vec::new(),
-                            error: Some(format!("Search error: {}", e)),
-                        });
-                        continue;
-                    }
-                };
+            let mut results = match search_client.search(
+                &trimmed,
+                limit,
+                boost_scope,
+                filter_scope,
+                recent_if_empty,
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    search_client.reconnect();
+                    let _ = evt_tx.send(WorkerEvent::SearchResults {
+                        id,
+                        results: Vec::new(),
+                        error: Some(format!("Search error: {}", e)),
+                    });
+                    continue;
+                }
+            };
 
             // Scope + Niyama filtering (best-effort).
             results.retain(|r| matches_filters(r, view, filter_scope, &niyamas));
@@ -200,6 +211,54 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
             }
         }
     }
+
+    status_stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _ = status_handle.join();
+}
+
+fn start_status_worker(
+    evt_tx: Sender<WorkerEvent>,
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut client = IpcClient::best_effort();
+        let mut last_status: Option<DaemonStatus> = None;
+        let mut failures = 0usize;
+
+        while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+            match client.status() {
+                Ok(status) => {
+                    failures = 0;
+                    last_status = Some(status.clone());
+                    let _ = evt_tx.send(WorkerEvent::Status {
+                        status: Some(status),
+                    });
+                }
+                Err(_) => {
+                    failures = failures.saturating_add(1);
+                    client.reconnect();
+
+                    if failures >= STATUS_FAILURES_BEFORE_OFFLINE {
+                        last_status = None;
+                        let _ = evt_tx.send(WorkerEvent::Status { status: None });
+                    } else if let Some(status) = last_status.clone() {
+                        let _ = evt_tx.send(WorkerEvent::Status {
+                            status: Some(status),
+                        });
+                    }
+                }
+            }
+
+            let mut slept = Duration::from_millis(0);
+            while slept < STATUS_POLL_INTERVAL {
+                if stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    return;
+                }
+                std::thread::sleep(STATUS_POLL_SLEEP_STEP);
+                slept += STATUS_POLL_SLEEP_STEP;
+            }
+        }
+    })
 }
 
 fn matches_filters(
@@ -547,7 +606,8 @@ mod tests {
     use std::io::{BufReader, Write};
     use std::os::unix::net::UnixListener;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
     use tempfile::tempdir;
     use vicaya_core::ipc::{BuildInfo, Request, Response};
 
@@ -858,7 +918,7 @@ mod tests {
                         requests.push(request);
                         let mut json = response.to_json().unwrap();
                         json.push('\n');
-                        stream.write_all(json.as_bytes()).unwrap();
+                        let _ = stream.write_all(json.as_bytes());
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -867,6 +927,137 @@ mod tests {
                 }
             }
             requests
+        })
+    }
+
+    fn start_status_blackhole_daemon(
+        vicaya_dir: &std::path::Path,
+        stop: Arc<AtomicBool>,
+    ) -> std::thread::JoinHandle<Vec<Request>> {
+        let socket = vicaya_dir.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream.set_nonblocking(false).unwrap();
+                        let requests = Arc::clone(&requests);
+                        let stop = Arc::clone(&stop);
+                        std::thread::spawn(move || {
+                            let mut reader = BufReader::new(stream.try_clone().unwrap());
+                            let Ok(Some(line)) = vicaya_core::ipc::read_message(&mut reader) else {
+                                return;
+                            };
+                            let Ok(request) = Request::from_json(&line) else {
+                                return;
+                            };
+                            requests.lock().unwrap().push(request.clone());
+
+                            match request {
+                                Request::Status => {
+                                    while !stop.load(Ordering::Relaxed) {
+                                        std::thread::sleep(Duration::from_millis(25));
+                                    }
+                                }
+                                Request::Search { .. } => {
+                                    let response = Response::SearchResults {
+                                        results: vec![vicaya_core::ipc::SearchResult {
+                                            path: "/tmp/repo/src/main.rs".to_string(),
+                                            name: "main.rs".to_string(),
+                                            score: 1.0,
+                                            size: 12,
+                                            mtime: 1_700_000_000,
+                                        }],
+                                    };
+                                    let mut json = response.to_json().unwrap();
+                                    json.push('\n');
+                                    stream.write_all(json.as_bytes()).unwrap();
+                                }
+                                _ => {}
+                            }
+                        });
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            requests.lock().unwrap().clone()
+        })
+    }
+
+    fn start_one_missed_status_daemon(
+        vicaya_dir: &std::path::Path,
+        stop: Arc<AtomicBool>,
+    ) -> std::thread::JoinHandle<Vec<Request>> {
+        let socket = vicaya_dir.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let status_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream.set_nonblocking(false).unwrap();
+                        let requests = Arc::clone(&requests);
+                        let status_count = Arc::clone(&status_count);
+                        std::thread::spawn(move || {
+                            let mut reader = BufReader::new(stream.try_clone().unwrap());
+                            while let Ok(Some(line)) = vicaya_core::ipc::read_message(&mut reader) {
+                                let Ok(request) = Request::from_json(&line) else {
+                                    return;
+                                };
+                                requests.lock().unwrap().push(request.clone());
+
+                                let response = match request {
+                                    Request::Status => {
+                                        let count =
+                                            status_count.fetch_add(1, Ordering::Relaxed) + 1;
+                                        if count == 2 {
+                                            return;
+                                        }
+
+                                        Response::Status {
+                                            pid: 77,
+                                            build: BuildInfo {
+                                                version: "1.2.0".to_string(),
+                                                git_sha: "abc1234".to_string(),
+                                                timestamp: "2026-05-19T00:00:00Z".to_string(),
+                                                target: "aarch64-apple-darwin".to_string(),
+                                            },
+                                            indexed_files: 3,
+                                            trigram_count: 9,
+                                            arena_size: 128,
+                                            index_allocated_bytes: 256,
+                                            state_allocated_bytes: 512,
+                                            last_updated: 1_700_000_000,
+                                            reconciling: false,
+                                        }
+                                    }
+                                    _ => Response::Ok,
+                                };
+
+                                let mut json = response.to_json().unwrap();
+                                json.push('\n');
+                                let _ = stream.write_all(json.as_bytes());
+                            }
+                        });
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            requests.lock().unwrap().clone()
         })
     }
 
@@ -981,5 +1172,100 @@ mod tests {
         assert!(!requests
             .iter()
             .any(|req| { matches!(req, Request::Search { query, .. } if query == "stale") }));
+    }
+
+    #[test]
+    fn worker_search_is_not_blocked_by_hung_status_connection() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let vicaya_dir = tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", vicaya_dir.path());
+        let stop = Arc::new(AtomicBool::new(false));
+        let fake_daemon = start_status_blackhole_daemon(vicaya_dir.path(), Arc::clone(&stop));
+
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+        let (evt_tx, evt_rx) = std::sync::mpsc::channel();
+        let worker = start_worker(cmd_rx, evt_tx);
+
+        std::thread::sleep(Duration::from_millis(250));
+        cmd_tx
+            .send(WorkerCommand::Search {
+                id: 1,
+                query: "main".to_string(),
+                limit: 10,
+                view: ViewKind::Patra,
+                boost_scope: Some(std::path::PathBuf::from("/tmp/repo")),
+                filter_scope: Some(std::path::PathBuf::from("/tmp/repo/src")),
+                niyamas: Vec::new(),
+            })
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut saw_search = false;
+        while Instant::now() < deadline {
+            if let Ok(WorkerEvent::SearchResults { id, results, error }) =
+                evt_rx.recv_timeout(Duration::from_millis(100))
+            {
+                if id == 1 {
+                    assert!(error.is_none(), "unexpected search error: {error:?}");
+                    assert_eq!(results.len(), 1);
+                    assert_eq!(results[0].name, "main.rs");
+                    saw_search = true;
+                    break;
+                }
+            }
+        }
+
+        cmd_tx.send(WorkerCommand::Quit).unwrap();
+        worker.join().unwrap();
+        stop.store(true, Ordering::Relaxed);
+        let requests = fake_daemon.join().unwrap();
+
+        assert!(saw_search, "search was blocked behind status polling");
+        assert!(requests.iter().any(|req| matches!(req, Request::Status)));
+        assert!(requests
+            .iter()
+            .any(|req| matches!(req, Request::Search { query, .. } if query == "main")));
+    }
+
+    #[test]
+    fn status_worker_keeps_last_status_after_one_missed_probe() {
+        let _lock = vicaya_core::paths::test_env_lock();
+        let vicaya_dir = tempdir().unwrap();
+        std::env::set_var("VICAYA_DIR", vicaya_dir.path());
+        let stop = Arc::new(AtomicBool::new(false));
+        let fake_daemon = start_one_missed_status_daemon(vicaya_dir.path(), Arc::clone(&stop));
+
+        let (evt_tx, evt_rx) = std::sync::mpsc::channel();
+        let status_worker = start_status_worker(evt_tx, Arc::clone(&stop));
+
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut statuses = Vec::new();
+        while Instant::now() < deadline && statuses.len() < 3 {
+            if let Ok(WorkerEvent::Status { status }) =
+                evt_rx.recv_timeout(Duration::from_millis(100))
+            {
+                statuses.push(status.map(|status| status.indexed_files));
+            }
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        status_worker.join().unwrap();
+        let requests = fake_daemon.join().unwrap();
+
+        assert!(
+            statuses.len() >= 3,
+            "expected status events before and after missed probe, got {statuses:?}"
+        );
+        assert!(
+            statuses.iter().all(|status| *status == Some(3)),
+            "single missed probe should not report daemon offline: {statuses:?}"
+        );
+        assert!(
+            requests
+                .iter()
+                .filter(|req| matches!(req, Request::Status))
+                .count()
+                >= 3
+        );
     }
 }


### PR DESCRIPTION
## Summary
- keep daemon IPC responsive during startup reconcile, rebuild swaps, and watcher churn
- make TUI status polling independent from search/preview work and resilient to stale sockets
- remove CLI search's long reconcile wait path so searches return immediately
- avoid daemon write-lock hotspots from watcher metadata, recent ordering, and scoped path ordering
- add regressions for multiple TUI clients, stale daemon sockets, hung status probes, watcher lock release, and scoped cache invalidation

## Main issue
The daemon was technically running, but foreground IPC could be starved by rebuild/reconcile cleanup and watcher update work. The TUI then made it worse by sharing a persistent socket and worker path between status and search, so one stale or hung status probe could make `rakshaka` appear offline and block filtering.

## Validation
- `make check`
- pre-push `lefthook` CI gate
- installed binaries: `vicaya`, `vicaya-tui`, `vicaya-daemon` all `1.2.2 rev 3bee257`
- `hyperfine --warmup 3 --runs 20` on installed daemon while reconcile active:
  - `vicaya status`: 6.0 ms mean
  - repo scoped search `kartaa-doctor.sh`: 5.8 ms mean
  - home scoped search `github_utils.py`: 9.7 ms mean
- home watcher churn stress while creating/moving/deleting files:
  - `vicaya status`: 5.9 ms mean
  - home scoped search `github_utils.py`: 6.4 ms mean
- `shux` TUI automation with two concurrent TUI instances, repo + home scopes, complex filters, preview toggle, action menu, scope overlay, view switcher, preview search, and navigation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable connection retry logic with timeout support for improved daemon reliability.
  * Introduced best-effort background status polling to prevent UI blocking.

* **Bug Fixes**
  * Improved search performance through optimized candidate ranking and indexing.
  * Fixed startup journal replay behavior for cleaner index initialization.

* **Refactor**
  * Reorganized search algorithm for faster, more accurate results.
  * Moved status polling to background thread for enhanced UI responsiveness.
  * Removed automatic empty-result retry in search to streamline behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/indrasvat/vicaya/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->