### PR TITLE
fix(tui): keep home searches responsive

### DIFF
--- a/crates/vicaya-index/src/query.rs
+++ b/crates/vicaya-index/src/query.rs
@@ -6,6 +6,10 @@ use std::cmp::{Ordering, Reverse};
 use std::collections::BinaryHeap;
 use std::path::{Path, PathBuf};
 
+const SHORT_QUERY_MAX_SCAN: usize = 50_000;
+const SHORT_QUERY_MIN_SCAN_AFTER_LIMIT: usize = 10_000;
+const INDEXED_QUERY_CANDIDATE_LIMIT: usize = 10_000;
+
 /// A search query.
 #[derive(Debug, Clone)]
 pub struct Query {
@@ -47,6 +51,13 @@ struct RankFeatures {
     path_depth: usize,
 }
 
+struct QueryContext<'b> {
+    boost_scope: Option<&'b Path>,
+    filter_scope: Option<&'b Path>,
+    cwd: Option<&'b Path>,
+    abbr_matcher: AbbreviationMatcher,
+}
+
 impl<'a> QueryEngine<'a> {
     /// Create a new query engine.
     pub fn new(
@@ -64,25 +75,43 @@ impl<'a> QueryEngine<'a> {
     /// Execute a search query.
     pub fn search(&self, query: &Query) -> Vec<SearchResult> {
         let normalized = query.term.to_lowercase();
-        let boost_scope = query.scope.as_deref();
-        let filter_scope = query.filter_scope.as_deref();
         let cwd = std::env::current_dir().ok();
-        let cwd = cwd.as_deref();
+        let context = QueryContext {
+            boost_scope: query.scope.as_deref(),
+            filter_scope: query.filter_scope.as_deref(),
+            cwd: cwd.as_deref(),
+            abbr_matcher: AbbreviationMatcher::new(),
+        };
 
         // For short queries, do a linear scan
         if normalized.len() < 3 {
-            return self.linear_search(&normalized, boost_scope, filter_scope, cwd, query.limit);
+            return self.linear_search(&normalized, query.limit, &context);
         }
 
         // Extract trigrams and query the index
         let trigrams = Trigram::extract(&normalized);
-        let candidates = self.trigram_index.query(&trigrams);
+        let candidates = if let Some(filter_scope) = context.filter_scope {
+            self.trigram_index.query_filtered_limited(
+                &trigrams,
+                INDEXED_QUERY_CANDIDATE_LIMIT,
+                |file_id| {
+                    let Some(meta) = self.file_table.get(file_id) else {
+                        return false;
+                    };
+                    let Some(path) = self.string_arena.get(meta.path_offset, meta.path_len) else {
+                        return false;
+                    };
+                    Self::scope_contains(Path::new(path), filter_scope, context.cwd)
+                },
+            )
+        } else {
+            self.trigram_index
+                .query_limited(&trigrams, INDEXED_QUERY_CANDIDATE_LIMIT)
+        };
 
         let mut ranked: Vec<(SearchResult, RankFeatures)> = Vec::with_capacity(query.limit);
         for file_id in candidates {
-            if let Some(result) =
-                self.score_candidate(file_id, &normalized, boost_scope, filter_scope, cwd)
-            {
+            if let Some(result) = self.score_candidate(file_id, &normalized, &context) {
                 self.push_ranked_candidate(&mut ranked, result, query.limit);
             }
         }
@@ -96,19 +125,15 @@ impl<'a> QueryEngine<'a> {
     /// subtree is cheaper than probing global posting lists and filtering afterward.
     pub fn search_file_ids(&self, query: &Query, file_ids: &[FileId]) -> Vec<SearchResult> {
         let normalized = query.term.to_lowercase();
-        let boost_scope = query.scope.as_deref();
-        let filter_scope = query.filter_scope.as_deref();
         let cwd = std::env::current_dir().ok();
-        let cwd = cwd.as_deref();
+        let context = QueryContext {
+            boost_scope: query.scope.as_deref(),
+            filter_scope: query.filter_scope.as_deref(),
+            cwd: cwd.as_deref(),
+            abbr_matcher: AbbreviationMatcher::new(),
+        };
 
-        self.search_file_ids_normalized(
-            &normalized,
-            boost_scope,
-            filter_scope,
-            cwd,
-            query.limit,
-            file_ids,
-        )
+        self.search_file_ids_normalized(&normalized, query.limit, file_ids, &context)
     }
 
     /// Score a candidate file.
@@ -116,9 +141,7 @@ impl<'a> QueryEngine<'a> {
         &self,
         file_id: FileId,
         query: &str,
-        boost_scope: Option<&Path>,
-        filter_scope: Option<&Path>,
-        cwd: Option<&Path>,
+        context: &QueryContext<'_>,
     ) -> Option<(SearchResult, RankFeatures)> {
         let meta = self.file_table.get(file_id)?;
 
@@ -126,8 +149,8 @@ impl<'a> QueryEngine<'a> {
         let name = self.string_arena.get(meta.name_offset, meta.name_len)?;
         let path_buf = Path::new(path);
 
-        if let Some(filter_scope) = filter_scope {
-            if !Self::scope_contains(path_buf, filter_scope, cwd) {
+        if let Some(filter_scope) = context.filter_scope {
+            if !Self::scope_contains(path_buf, filter_scope, context.cwd) {
                 return None;
             }
         }
@@ -143,11 +166,11 @@ impl<'a> QueryEngine<'a> {
                 None
             };
 
-        let abbr_score = if substring_score == Some(1.0) || is_literal_filename_query(query) {
+        let abbr_score = if substring_score.is_some() || is_literal_filename_query(query) {
             None
         } else {
-            let abbr_matcher = AbbreviationMatcher::new();
-            abbr_matcher
+            context
+                .abbr_matcher
                 .match_path(query, path)
                 .map(|abbr_match| abbr_match.score)
         };
@@ -163,7 +186,7 @@ impl<'a> QueryEngine<'a> {
         let path_depth = Self::path_depth(path);
         let features = RankFeatures {
             context_score: Self::context_score(path_lower.as_ref())
-                + Self::scope_boost(path_buf, boost_scope, cwd),
+                + Self::scope_boost(path_buf, context.boost_scope, context.cwd),
             path_depth,
         };
 
@@ -212,10 +235,8 @@ impl<'a> QueryEngine<'a> {
     fn linear_search(
         &self,
         query: &str,
-        boost_scope: Option<&Path>,
-        filter_scope: Option<&Path>,
-        cwd: Option<&Path>,
         limit: usize,
+        context: &QueryContext<'_>,
     ) -> Vec<SearchResult> {
         if limit == 0 {
             return Vec::new();
@@ -228,13 +249,19 @@ impl<'a> QueryEngine<'a> {
 
         for (scanned, (file_id, _meta)) in self.file_table.iter().enumerate() {
             // Early termination for non-matching queries
-            if filter_scope.is_none() && ranked.is_empty() && scanned >= MAX_EMPTY_SCAN {
+            if context.filter_scope.is_none() && ranked.is_empty() && scanned >= MAX_EMPTY_SCAN {
+                break;
+            }
+            // One- and two-character queries are inherently broad over large home
+            // indexes. Keep them interactive by sampling enough candidates to rank
+            // useful results without letting a single keystroke monopolize daemon IPC.
+            if scanned >= SHORT_QUERY_MAX_SCAN
+                || (ranked.len() >= limit && scanned >= SHORT_QUERY_MIN_SCAN_AFTER_LIMIT)
+            {
                 break;
             }
 
-            if let Some(result) =
-                self.score_candidate(file_id, query, boost_scope, filter_scope, cwd)
-            {
+            if let Some(result) = self.score_candidate(file_id, query, context) {
                 self.push_ranked_candidate(&mut ranked, result, limit);
             }
         }
@@ -246,11 +273,9 @@ impl<'a> QueryEngine<'a> {
     fn search_file_ids_normalized(
         &self,
         query: &str,
-        boost_scope: Option<&Path>,
-        filter_scope: Option<&Path>,
-        cwd: Option<&Path>,
         limit: usize,
         file_ids: &[FileId],
+        context: &QueryContext<'_>,
     ) -> Vec<SearchResult> {
         if limit == 0 {
             return Vec::new();
@@ -258,9 +283,7 @@ impl<'a> QueryEngine<'a> {
 
         let mut ranked: Vec<(SearchResult, RankFeatures)> = Vec::with_capacity(limit);
         for &file_id in file_ids {
-            if let Some(result) =
-                self.score_candidate(file_id, query, boost_scope, filter_scope, cwd)
-            {
+            if let Some(result) = self.score_candidate(file_id, query, context) {
                 self.push_ranked_candidate(&mut ranked, result, limit);
             }
         }
@@ -869,6 +892,97 @@ mod tests {
         let results = engine.search(&query);
         let names: Vec<_> = results.iter().map(|r| r.name.as_str()).collect();
         assert_eq!(names, vec!["search.rs", "server.rs"]);
+    }
+
+    #[test]
+    fn test_common_indexed_queries_are_candidate_capped() {
+        let mut file_table = FileTable::new();
+        let mut arena = StringArena::new();
+        let mut index = TrigramIndex::new();
+
+        for i in 0..15_000 {
+            let path = format!("/home/user/site-packages/pkg_{i}/RECORD");
+            let name = "RECORD";
+            let (path_off, path_len) = arena.add(&path);
+            let (name_off, name_len) = arena.add(name);
+            let meta = FileMeta {
+                path_offset: path_off,
+                path_len,
+                name_offset: name_off,
+                name_len,
+                size: 1024,
+                mtime: i,
+                dev: 0,
+                ino: i as u64,
+            };
+
+            let file_id = file_table.insert(meta);
+            index.add(file_id, name);
+        }
+
+        let engine = QueryEngine::new(&file_table, &arena, &index);
+        let results = engine.search(&Query {
+            term: "record".to_string(),
+            limit: 10,
+            scope: Some(PathBuf::from("/home/user")),
+            filter_scope: None,
+        });
+
+        assert_eq!(results.len(), 10);
+        assert!(results.iter().all(|result| result.name == "RECORD"));
+    }
+
+    #[test]
+    fn test_scoped_indexed_search_filters_before_effective_limit() {
+        let mut file_table = FileTable::new();
+        let mut arena = StringArena::new();
+        let mut index = TrigramIndex::new();
+
+        for i in 0..(INDEXED_QUERY_CANDIDATE_LIMIT + 10) {
+            let path = format!("/outside/site-packages/pkg_{i}/RECORD");
+            let name = "RECORD";
+            let (path_off, path_len) = arena.add(&path);
+            let (name_off, name_len) = arena.add(name);
+            let meta = FileMeta {
+                path_offset: path_off,
+                path_len,
+                name_offset: name_off,
+                name_len,
+                size: 1024,
+                mtime: i as i64,
+                dev: 0,
+                ino: i as u64,
+            };
+
+            let file_id = file_table.insert(meta);
+            index.add(file_id, name);
+        }
+
+        let inside_path = "/inside/notes/recording.md";
+        let (path_off, path_len) = arena.add(inside_path);
+        let (name_off, name_len) = arena.add("recording.md");
+        let file_id = file_table.insert(FileMeta {
+            path_offset: path_off,
+            path_len,
+            name_offset: name_off,
+            name_len,
+            size: 512,
+            mtime: 99_999,
+            dev: 0,
+            ino: 99_999,
+        });
+        index.add(file_id, "recording.md");
+
+        let engine = QueryEngine::new(&file_table, &arena, &index);
+        let results = engine.search(&Query {
+            term: "record".to_string(),
+            limit: 10,
+            scope: Some(PathBuf::from("/inside")),
+            filter_scope: Some(PathBuf::from("/inside")),
+        });
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, inside_path);
     }
 
     #[test]

--- a/crates/vicaya-index/src/trigram.rs
+++ b/crates/vicaya-index/src/trigram.rs
@@ -98,6 +98,30 @@ impl TrigramIndex {
 
     /// Query the index for files containing all given trigrams.
     pub fn query(&self, trigrams: &[Trigram]) -> Vec<FileId> {
+        self.query_limited(trigrams, usize::MAX)
+    }
+
+    /// Query the index for files containing all given trigrams, stopping after
+    /// `max_results` candidates.
+    pub fn query_limited(&self, trigrams: &[Trigram], max_results: usize) -> Vec<FileId> {
+        self.query_filtered_limited(trigrams, max_results, |_| true)
+    }
+
+    /// Query the index for files containing all given trigrams, applying `accept`
+    /// before counting a candidate against `max_results`.
+    pub fn query_filtered_limited<F>(
+        &self,
+        trigrams: &[Trigram],
+        max_results: usize,
+        mut accept: F,
+    ) -> Vec<FileId>
+    where
+        F: FnMut(FileId) -> bool,
+    {
+        if max_results == 0 {
+            return Vec::new();
+        }
+
         if trigrams.is_empty() {
             return Vec::new();
         }
@@ -124,6 +148,8 @@ impl TrigramIndex {
         smallest
             .iter()
             .filter(|&&file_id| rest.iter().all(|list| list.binary_search(&file_id).is_ok()))
+            .filter(|&&file_id| accept(file_id))
+            .take(max_results)
             .copied()
             .collect()
     }
@@ -190,5 +216,17 @@ mod tests {
 
         let results = index.query(&Trigram::extract("hel"));
         assert_eq!(results, vec![FileId(1), FileId(2), FileId(3)]);
+    }
+
+    #[test]
+    fn query_limited_caps_common_posting_lists() {
+        let mut index = TrigramIndex::new();
+
+        for id in 0..10 {
+            index.add(FileId(id), "record");
+        }
+
+        let results = index.query_limited(&Trigram::extract("record"), 3);
+        assert_eq!(results, vec![FileId(0), FileId(1), FileId(2)]);
     }
 }

--- a/crates/vicaya-tui/src/app.rs
+++ b/crates/vicaya-tui/src/app.rs
@@ -993,13 +993,12 @@ fn trigger_search(
     search_id: &mut u64,
     active_search_id: &mut u64,
     last_search_sent_at: &mut std::time::Instant,
-) {
+) -> bool {
     let parsed = crate::state::parse_query(&app.search.query);
 
-    app.search.is_searching = true;
     *search_id = (*search_id).wrapping_add(1);
     *active_search_id = *search_id;
-    let _ = cmd_tx.send(WorkerCommand::Search {
+    let command = WorkerCommand::Search {
         id: *active_search_id,
         query: parsed.term,
         limit: 100,
@@ -1007,8 +1006,17 @@ fn trigger_search(
         boost_scope: app.ksetra.current().cloned(),
         filter_scope: app.ksetra.current().cloned(),
         niyamas: parsed.niyamas,
-    });
+    };
+
+    if cmd_tx.send(command).is_err() {
+        app.search.is_searching = false;
+        app.error = Some("Search worker is unavailable".to_string());
+        return false;
+    }
+
+    app.search.is_searching = true;
     *last_search_sent_at = std::time::Instant::now();
+    true
 }
 
 /// Copy path to clipboard
@@ -1287,6 +1295,24 @@ mod tests {
     }
 
     #[test]
+    fn narrow_terminal_control_overlays_do_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = AppState::with_startup_scope(Some(dir.path().to_path_buf()));
+
+        handle_key_event(&mut app, KeyCode::Char('k'), KeyModifiers::CONTROL);
+        assert_eq!(app.mode, AppMode::KsetraInput);
+        let ksetra = buffer_text(&mut app, 48, 24);
+        assert!(ksetra.contains("ksetra"));
+
+        handle_key_event(&mut app, KeyCode::Esc, KeyModifiers::NONE);
+        app.search.focus = FocusTarget::Preview;
+        handle_key_event(&mut app, KeyCode::Char('/'), KeyModifiers::NONE);
+        assert_eq!(app.mode, AppMode::PreviewSearch);
+        let preview = buffer_text(&mut app, 42, 20);
+        assert!(preview.contains("preview"));
+    }
+
+    #[test]
     fn drishti_switcher_selects_enabled_views_and_reports_disabled_views() {
         let mut app = AppState::new();
 
@@ -1425,13 +1451,13 @@ mod tests {
         let mut active_search_id = 0;
         let mut last = std::time::Instant::now();
 
-        trigger_search(
+        assert!(trigger_search(
             &tx,
             &mut app,
             &mut search_id,
             &mut active_search_id,
             &mut last,
-        );
+        ));
 
         match rx.try_recv().unwrap() {
             WorkerCommand::Search {
@@ -1455,6 +1481,28 @@ mod tests {
         assert_eq!(search_id, 1);
         assert_eq!(active_search_id, 1);
         assert!(app.search.is_searching);
+    }
+
+    #[test]
+    fn trigger_search_does_not_leave_tui_stuck_when_worker_is_gone() {
+        let (tx, rx) = mpsc::channel();
+        drop(rx);
+        let mut app = AppState::new();
+        app.search.set_query("record".to_string());
+        let mut search_id = 0;
+        let mut active_search_id = 0;
+        let mut last = std::time::Instant::now();
+
+        assert!(!trigger_search(
+            &tx,
+            &mut app,
+            &mut search_id,
+            &mut active_search_id,
+            &mut last,
+        ));
+
+        assert!(!app.search.is_searching);
+        assert_eq!(app.error.as_deref(), Some("Search worker is unavailable"));
     }
 
     #[test]
@@ -1498,6 +1546,7 @@ mod tests {
         app.preview.start_search();
         app.preview.insert_search_char('d');
         assert!(buffer_text(&mut app, 100, 28).contains("preview"));
+        assert!(buffer_text(&mut app, 42, 20).contains("preview"));
 
         app.mode = AppMode::KsetraInput;
         app.ksetra_input.input = dir.path().to_string_lossy().to_string();
@@ -1505,6 +1554,7 @@ mod tests {
         app.ksetra_input
             .set_completions(vec![dir.path().to_string_lossy().to_string()]);
         assert!(buffer_text(&mut app, 100, 28).contains("ksetra"));
+        assert!(buffer_text(&mut app, 48, 24).contains("ksetra"));
 
         app.mode = AppMode::Confirm(crate::state::Action::Quit);
         assert!(buffer_text(&mut app, 100, 28).contains("sure"));

--- a/crates/vicaya-tui/src/client/mod.rs
+++ b/crates/vicaya-tui/src/client/mod.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use vicaya_core::ipc::{Request, Response};
 use vicaya_index::SearchResult;
 
-const IPC_TIMEOUT: Duration = Duration::from_secs(2);
+const IPC_TIMEOUT: Duration = Duration::from_secs(10);
 const REQUEST_ATTEMPTS: usize = 3;
 
 /// IPC client for daemon communication.

--- a/crates/vicaya-tui/src/ui/overlays.rs
+++ b/crates/vicaya-tui/src/ui/overlays.rs
@@ -273,8 +273,7 @@ pub fn render_kriya_suchi(f: &mut Frame, app: &AppState) {
 
 pub fn render_preview_search(f: &mut Frame, app: &AppState) {
     let root = f.area();
-    let width = ((root.width as f32) * 0.72) as u16;
-    let width = width.clamp(40, root.width.saturating_sub(2));
+    let width = overlay_width(root, 0.72, 40, 2);
     let height = 5u16;
     let area = centered_fixed_rect(width, height, root);
 
@@ -305,9 +304,19 @@ pub fn render_preview_search(f: &mut Frame, app: &AppState) {
     f.render_widget(input, area);
 
     let cursor_display_width = ui::display_width_up_to(query, app.preview.search_cursor) as u16;
-    let cursor_x = area.x + 1 + "purvadarshana /: ".len() as u16 + cursor_display_width;
+    let cursor_offset = ("purvadarshana /: ".len() as u16)
+        .saturating_add(cursor_display_width)
+        .min(area.width.saturating_sub(2).saturating_sub(1));
+    let cursor_x = area.x + 1 + cursor_offset;
     let cursor_y = area.y + 1;
     f.set_cursor_position((cursor_x, cursor_y));
+}
+
+fn overlay_width(root: Rect, fraction: f32, preferred_min: u16, margin: u16) -> u16 {
+    let max_width = root.width.saturating_sub(margin).max(1);
+    let min_width = preferred_min.min(max_width);
+    let desired = ((root.width as f32) * fraction) as u16;
+    desired.clamp(min_width, max_width)
 }
 
 fn centered_fixed_rect(width: u16, height: u16, r: Rect) -> Rect {
@@ -329,8 +338,7 @@ pub fn render_ksetra_input(f: &mut Frame, app: &AppState) {
     use ratatui::widgets::ListState;
 
     let root = f.area();
-    let width = ((root.width as f32) * 0.75) as u16;
-    let width = width.clamp(50, root.width.saturating_sub(4));
+    let width = overlay_width(root, 0.75, 50, 4);
 
     // Height: input (3) + completions (up to 7) + help (2) + borders
     let completions_count = app.ksetra_input.completions.len().min(5);
@@ -389,7 +397,12 @@ pub fn render_ksetra_input(f: &mut Frame, app: &AppState) {
     f.render_widget(input_widget, chunks[0]);
 
     // Set cursor position
-    let cursor_x = chunks[0].x + 1 + "path: ".len() as u16 + app.ksetra_input.cursor as u16;
+    let cursor_display_width =
+        ui::display_width_up_to(&app.ksetra_input.input, app.ksetra_input.cursor) as u16;
+    let cursor_offset = ("path: ".len() as u16)
+        .saturating_add(cursor_display_width)
+        .min(chunks[0].width.saturating_sub(2).saturating_sub(1));
+    let cursor_x = chunks[0].x + 1 + cursor_offset;
     let cursor_y = chunks[0].y + 1;
     f.set_cursor_position((cursor_x, cursor_y));
 


### PR DESCRIPTION
## Summary

Fixes the home-scope TUI hang/regression seen when searching broad terms like `record` from `~/`, and fixes the Ctrl+K crash in narrow SSH/Echo-style terminals.

## What changed

- Caps broad indexed query candidate scans with scope filtering applied before the effective cap, so scoped searches stay fast without dropping valid in-scope results.
- Bounds short-query linear scans and reuses abbreviation matcher state per query.
- Skips expensive abbreviation scoring when substring scoring already matched.
- Makes TUI search-worker send failure explicit so the UI cannot stay stuck on `searching...` when the worker is unavailable.
- Fixes narrow overlay width/cursor math so Ctrl+K and preview overlays do not panic on small terminals.
- Adds regressions for broad indexed queries, scope-before-cap behavior, narrow overlays, and missing worker search responses.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make ci` via pre-push hook
- GitHub checks: 12/12 passing on `4fc478c`
- Installed local binaries from `4fc478c` and restarted daemon
- `hyperfine` from `~/` on a 1,925,138-file index after `reconciling=false`:
  - `record`: 46.1 ms mean
  - `rec`: 45.7 ms mean
  - `re`: 51.0 ms mean
  - `status`: 7.2 ms mean
- `shux` interactive checks:
  - 100x40 `~/` TUI: `record`, Tab focus, preview search, Ctrl+K
  - 48x24 narrow SSH/Echo-like TUI: `record`, Ctrl+K
  - daemon stayed online and responsive during stress
