### PR TITLE
fix(site): widen desktop stack diagram

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,7 @@
       rel="icon"
       href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="12" fill="%23121218"/><text x="32" y="42" text-anchor="middle" font-size="30" font-weight="800" fill="%23FFB347">वि</text></svg>'
     />
-    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./styles.css?v=20260521-desktop-stack" />
   </head>
   <body>
     <header class="site-header">

--- a/site/styles.css
+++ b/site/styles.css
@@ -392,8 +392,8 @@ dd {
 
 .system {
   display: grid;
-  grid-template-columns: minmax(0, 0.82fr) minmax(420px, 1fr);
-  gap: 42px;
+  grid-template-columns: minmax(280px, 0.72fr) minmax(720px, 1.28fr);
+  gap: 44px;
   align-items: center;
   border-top: 1px solid var(--line-soft);
   background:
@@ -404,7 +404,7 @@ dd {
 .component-visual {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 84px minmax(180px, 0.9fr) 84px minmax(0, 1fr);
+  grid-template-columns: minmax(160px, 1fr) 72px minmax(190px, 0.95fr) 72px minmax(160px, 1fr);
   align-items: center;
   min-height: 260px;
   padding: 22px;
@@ -634,7 +634,7 @@ footer a:hover {
   color: var(--accent);
 }
 
-@media (max-width: 1120px) {
+@media (max-width: 1280px) {
   h1 {
     font-size: 5rem;
   }


### PR DESCRIPTION
## Summary
- widen the desktop component diagram so CLI/TUI cards do not collapse
- switch the system section to stacked layout earlier on narrower desktops
- cache-bust the site stylesheet so Pages refreshes the fixed layout reliably

## Validation
- agent-browser screenshot at 1366x768: .shux/out/vicaya-desktop-system-1366-after-wide.png
- agent-browser screenshot at 1095x379: .shux/out/vicaya-desktop-system-1095-after.png
- agent-browser mobile regression screenshot at 390x844: .shux/out/vicaya-mobile-hero-after-desktop-fix.png
- git diff --check
- pre-push make ci: format, clippy, tests, build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted layout grid definitions and spacing ratios for optimized component alignment.
  * Extended responsive design breakpoint to 1280px for improved mobile experience on wider screens.
  * Implemented stylesheet cache-busting to ensure users receive style updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/indrasvat/vicaya/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->