### PR TITLE
feat(content-search): add antarvicaya grep

### DIFF
--- a/.shux/scripts/content-search-visual.sh
+++ b/.shux/scripts/content-search-visual.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="$ROOT/.shux/out/content-search"
+STATE="$ROOT/.shux/out/content-search-state"
+SESSION="vicaya-content-search"
+VICAYA_BIN="$ROOT/target/release/vicaya"
+VICAYA_TUI_BIN="$ROOT/target/release/vicaya-tui"
+VICAYA_DAEMON_BIN="$ROOT/target/release/vicaya-daemon"
+
+mkdir -p "$OUT" "$STATE"
+rm -f "$OUT"/*.png
+
+cargo build --release --workspace
+
+cat > "$STATE/config.toml" <<EOF
+index_roots = ["$ROOT"]
+exclusions = [".git", "target", "node_modules", ".shux/out"]
+respect_ignore_files = true
+index_path = "$STATE/index"
+max_memory_mb = 128
+
+[performance]
+scanner_threads = 2
+reconcile_hour = 3
+
+[smriti]
+enabled = true
+max_entries = 10000
+max_boost = 0.08
+
+[content_search]
+enabled = true
+engine = "auto"
+allow_slow_fallback = false
+EOF
+
+cleanup() {
+  env VICAYA_DIR="$STATE" VICAYA_DAEMON_BIN="$VICAYA_DAEMON_BIN" "$VICAYA_BIN" daemon stop >/dev/null 2>&1 || true
+  shux session kill "$SESSION" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cleanup
+env VICAYA_DIR="$STATE" VICAYA_DAEMON_BIN="$VICAYA_DAEMON_BIN" "$VICAYA_BIN" daemon start >/dev/null
+
+snapshot() {
+  local name="$1"
+  shux --format json pane snapshot -s "$SESSION" | jq -r .png_base64 | base64 -d > "$OUT/$name.png"
+}
+
+start_tui() {
+  local title="$1"
+  shift
+  shux session kill "$SESSION" >/dev/null 2>&1 || true
+  shux --format json session create "$SESSION" -d --title "$title" --cwd "$ROOT" -- \
+    env VICAYA_DIR="$STATE" \
+      VICAYA_DAEMON_BIN="$VICAYA_DAEMON_BIN" \
+      VICAYA_NO_UPDATE_CHECK=1 \
+      "$@" \
+      "$VICAYA_TUI_BIN" "$ROOT" >/dev/null
+  shux pane set-size -s "$SESSION" --cols 140 --rows 42
+  shux pane wait-for -s "$SESSION" --text "vicaya" --timeout-ms 10000
+}
+
+select_content_drishti() {
+  shux pane send-keys -s "$SESSION" --data FA==
+  shux pane wait-for -s "$SESSION" --text "drishti" --timeout-ms 10000
+  shux pane send-keys -s "$SESSION" --text "antar"
+  snapshot "$1"
+  shux pane send-keys -s "$SESSION" --data DQ==
+  shux pane wait-for -s "$SESSION" --text "Antarvicaya" --timeout-ms 10000
+}
+
+start_tui "vicaya-content-search"
+snapshot "01-patra-startup"
+select_content_drishti "02-drishti-antar-filter"
+shux pane send-keys -s "$SESSION" --text "fn main"
+shux pane wait-for -s "$SESSION" --text "main.rs" --timeout-ms 10000
+snapshot "03-content-results-ripgrep"
+
+shux pane set-size -s "$SESSION" --cols 82 --rows 24
+sleep 0.4
+snapshot "04-content-narrow"
+
+shux pane set-size -s "$SESSION" --cols 170 --rows 48
+sleep 0.4
+snapshot "05-content-wide"
+
+start_tui "vicaya-content-git-grep" VICAYA_CONTENT_SEARCH_ENGINE=git-grep
+select_content_drishti "06-git-grep-drishti"
+shux pane send-keys -s "$SESSION" --text "content search"
+shux pane wait-for -s "$SESSION" --text "README.md" --timeout-ms 10000
+snapshot "07-content-results-git-grep"
+
+start_tui "vicaya-content-disabled" VICAYA_NO_CONTENT_SEARCH=1
+select_content_drishti "08-disabled-drishti"
+shux pane send-keys -s "$SESSION" --text "needle"
+sleep 1
+snapshot "09-content-disabled-error"
+
+env VICAYA_DIR="$STATE" VICAYA_DAEMON_BIN="$VICAYA_DAEMON_BIN" "$VICAYA_BIN" status --format json > "$OUT/daemon-status.json"
+
+echo "Content search shux screenshots written to $OUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+* **content-search:** add scoped grep CLI and Antarvicaya TUI drishti
 * **smriti:** add local usage-memory ranking and TUI history view
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Project site and release manifest: <https://indrasvat.github.io/vicaya/>
 
-vicaya is a lightweight developer file finder inspired by "Everything" on Windows. It finds files and folders by filename, path, and metadata; it does not index file contents. Use vicaya to locate the right path, then use tools like `ripgrep` when you need content search.
+vicaya is a lightweight developer file finder inspired by "Everything" on Windows. It keeps filename, path, and metadata search instant through its daemon index, and adds scoped content search through local tools when you need to look inside files.
 
 ## Features
 
@@ -16,6 +16,7 @@ vicaya is a lightweight developer file finder inspired by "Everything" on Window
 - **Repo-Aware Indexing**: Honors `.gitignore`, `.ignore`, and `.git/info/exclude` by default
 - **Developer Ranking**: Prefers exact/prefix/abbreviation matches and demotes noisy dependency/cache paths
 - **Smriti Frecency**: Learns local usage from opens/copies/reveals/prints to promote the paths you repeatedly choose
+- **Scoped Content Search**: `vicaya grep` and the `Antarvicaya` TUI drishti use `rg`, fall back to `git grep` in repos, and keep plain `grep` explicit
 - **Composable Output**: Table, plain, and JSON formats for shells, `fzf`, scripts, and agents
 - **Compact Index**: Efficient string arena + trigram index persisted to disk
 - **CLI, Daemon & TUI**: Command-line tools, always-on daemon, and terminal UI for instant results
@@ -128,6 +129,11 @@ vicaya rebuild
 vicaya search "main.rs" --limit 10
 vicaya search "query.rs" --scope ~/code/github.com/example-repo --limit 10
 
+# Search file contents without touching the daemon
+vicaya grep "fn main" --scope ~/code/github.com/example-repo --limit 20
+vicaya grep "TODO" --scope . --engine git-grep --format json
+vicaya grep "needle" --scope . --engine grep --allow-slow-fallback
+
 # Check daemon/index status
 vicaya status
 
@@ -173,7 +179,7 @@ The TUI connects to the same daemon and gives you instant, fuzzy-as-you-type res
 Highlights:
 
 - Split view: `phala` (results) + `purvadarshana` (preview with syntax highlighting)
-- `Ctrl+T` opens the searchable `drishti` switcher (Patra = Files, Sthana = Directories, Smriti = usage memory)
+- `Ctrl+T` opens the searchable `drishti` switcher (Patra = Files, Sthana = Directories, Smriti = usage memory, Antarvicaya = content)
 - `Enter` on a directory pushes `ksetra` scope; `h` pops scope (breadcrumbs in header)
 - Launch with `vicaya-tui .` or `vicaya-tui /some/dir` to start with `ksetra` already applied
 - `Niyama` filters in `prashna`: `type:file|dir`, `ext:rs,md`, `path:src/`, `mtime:<7d`, `size:>10mb`
@@ -222,6 +228,15 @@ sends usage data anywhere; it only stores local path/action counters in
 `smriti.json.corrupt.<timestamp>` before Vicaya starts a fresh store. Set
 `VICAYA_NO_SMRITI=1` or disable `[smriti] enabled` when you want searches to
 ignore usage memory entirely.
+
+`[content_search] enabled = true` is the default. `engine = "auto"` prefers
+`rg`, then `git grep` when the active scope is inside a git worktree. Plain
+recursive `grep` is intentionally opt-in via `--engine grep`,
+`--allow-slow-fallback`, or `[content_search] allow_slow_fallback = true`;
+this keeps search-as-you-type responsive when `rg` is not installed. Existing
+config files without a `[content_search]` table do not need migration; Vicaya
+applies these defaults in memory after upgrade. Set `VICAYA_NO_CONTENT_SEARCH=1`
+to disable the feature.
 
 ## Make Targets Reference
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -37,3 +37,13 @@ max_entries = 10000
 
 # Maximum score boost applied to matching search results
 max_boost = 0.08
+
+[content_search]
+# Powers `vicaya grep` and the Antarvicaya TUI drishti.
+enabled = true
+
+# auto prefers ripgrep, then git-grep inside a worktree.
+engine = "auto"
+
+# Keep this false unless you explicitly accept slower recursive grep fallback.
+allow_slow_fallback = false

--- a/crates/vicaya-cli/src/main.rs
+++ b/crates/vicaya-cli/src/main.rs
@@ -4,7 +4,7 @@ mod ipc_client;
 mod metrics;
 mod upgrade;
 
-use clap::{ArgAction, Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use std::path::{Path, PathBuf};
 use tracing::info;
 use vicaya_core::ipc::{Request, Response};
@@ -57,6 +57,32 @@ enum Commands {
         scope: Option<PathBuf>,
     },
 
+    /// Search file contents in a scope
+    Grep {
+        /// Literal content query
+        query: String,
+
+        /// Maximum number of matches
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+
+        /// Output format (table, json, plain)
+        #[arg(short, long, default_value = "table")]
+        format: String,
+
+        /// Restrict content search to this directory or file
+        #[arg(long, value_name = "PATH")]
+        scope: Option<PathBuf>,
+
+        /// Content search engine
+        #[arg(long, value_enum)]
+        engine: Option<ContentEngineCli>,
+
+        /// Permit recursive grep when ripgrep/git-grep are unavailable
+        #[arg(long)]
+        allow_slow_fallback: bool,
+    },
+
     /// Rebuild the index
     Rebuild {
         /// Dry run (don't actually write)
@@ -101,6 +127,25 @@ enum DaemonAction {
     Stop,
     /// Check daemon status
     Status,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ContentEngineCli {
+    Auto,
+    Ripgrep,
+    GitGrep,
+    Grep,
+}
+
+impl From<ContentEngineCli> for vicaya_core::content_search::ContentSearchEngineChoice {
+    fn from(value: ContentEngineCli) -> Self {
+        match value {
+            ContentEngineCli::Auto => Self::Auto,
+            ContentEngineCli::Ripgrep => Self::Ripgrep,
+            ContentEngineCli::GitGrep => Self::GitGrep,
+            ContentEngineCli::Grep => Self::Grep,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -165,6 +210,23 @@ fn main() -> Result<()> {
         }) => {
             search(&query, limit, &format, scope.as_deref())?;
         }
+        Some(Commands::Grep {
+            query,
+            limit,
+            format,
+            scope,
+            engine,
+            allow_slow_fallback,
+        }) => {
+            grep(
+                &query,
+                limit,
+                &format,
+                scope.as_deref(),
+                engine,
+                allow_slow_fallback,
+            )?;
+        }
         Some(Commands::Rebuild { dry_run }) => {
             rebuild(dry_run)?;
         }
@@ -196,6 +258,101 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn grep(
+    query: &str,
+    limit: usize,
+    format: &str,
+    scope: Option<&Path>,
+    engine: Option<ContentEngineCli>,
+    allow_slow_fallback: bool,
+) -> Result<()> {
+    let config = load_config()?;
+    if !config.content_search_enabled() {
+        return Err(vicaya_core::Error::Other(
+            "content search is disabled by config or VICAYA_NO_CONTENT_SEARCH".into(),
+        ));
+    }
+
+    let scope = scope
+        .map(resolve_content_scope)
+        .transpose()?
+        .unwrap_or(std::env::current_dir()?);
+    let engine = engine
+        .map(Into::into)
+        .map(Ok)
+        .unwrap_or_else(|| config.content_search_engine())?;
+
+    let mut options = vicaya_core::content_search::ContentSearchOptions::new(query, scope, limit);
+    options.engine = engine;
+    options.allow_slow_fallback =
+        allow_slow_fallback || config.content_search_allow_slow_fallback();
+    options.rg_path = config.content_search.rg_path.clone();
+
+    let report = vicaya_core::content_search::search(&options)?;
+
+    match format {
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        }
+        "plain" => {
+            for hit in &report.hits {
+                let column = hit
+                    .column
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "-".to_string());
+                println!(
+                    "{}:{}:{}:{}",
+                    hit.path.display(),
+                    hit.line_number,
+                    column,
+                    hit.line
+                );
+            }
+        }
+        _ => {
+            println!("Engine: {}", report.engine.label());
+            println!("{:<6} {:<10} {:<8} MATCH", "RANK", "LINE", "COL");
+            for (i, hit) in report.hits.iter().enumerate() {
+                let column = hit
+                    .column
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "-".to_string());
+                println!(
+                    "{:<6} {:<10} {:<8} {}:{} {}",
+                    i + 1,
+                    hit.line_number,
+                    column,
+                    hit.path.display(),
+                    hit.line_number,
+                    hit.line.trim()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_content_scope(path: &Path) -> Result<PathBuf> {
+    let normalized = vicaya_core::paths::resolve_user_path(path)?;
+    let metadata = std::fs::metadata(&normalized).map_err(|err| {
+        vicaya_core::Error::Other(format!(
+            "Failed to resolve content search scope '{}': {}",
+            path.display(),
+            err
+        ))
+    })?;
+
+    if !metadata.is_dir() && !metadata.is_file() {
+        return Err(vicaya_core::Error::Other(format!(
+            "Content search scope '{}' is not a file or directory",
+            path.display()
+        )));
+    }
+
+    Ok(normalized)
 }
 
 fn build_search_request(query: &str, limit: usize, scope: Option<&Path>) -> Result<Request> {
@@ -978,6 +1135,14 @@ max_memory_mb = 512
 scanner_threads = {}
 # Hour of day (0-23) to run automatic reconciliation
 reconcile_hour = 3
+
+[content_search]
+# Content search powers `vicaya grep` and the Antarvicaya TUI drishti.
+enabled = true
+# auto prefers ripgrep, then git-grep inside a worktree.
+engine = "auto"
+# Keep this false unless you explicitly accept slower recursive grep fallback.
+allow_slow_fallback = false
 "#,
         index_dir.display(),
         num_cpus::get().max(2)
@@ -1025,6 +1190,34 @@ mod tests {
         match cli.command {
             Some(Commands::Search { scope, .. }) => {
                 assert_eq!(scope, Some(PathBuf::from("/tmp/repo")));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_grep_engine_and_slow_fallback() {
+        let cli = Cli::parse_from([
+            "vicaya",
+            "grep",
+            "needle",
+            "--scope",
+            "/tmp/repo",
+            "--engine",
+            "git-grep",
+            "--allow-slow-fallback",
+        ]);
+
+        match cli.command {
+            Some(Commands::Grep {
+                scope,
+                engine,
+                allow_slow_fallback,
+                ..
+            }) => {
+                assert_eq!(scope, Some(PathBuf::from("/tmp/repo")));
+                assert!(matches!(engine, Some(ContentEngineCli::GitGrep)));
+                assert!(allow_slow_fallback);
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/crates/vicaya-cli/tests/cli_operational_flows.rs
+++ b/crates/vicaya-cli/tests/cli_operational_flows.rs
@@ -71,6 +71,7 @@ fn write_config(vicaya_dir: &Path, root: &Path) {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
     std::fs::create_dir_all(vicaya_dir).unwrap();
     config.save(&vicaya_dir.join("config.toml")).unwrap();
@@ -121,6 +122,79 @@ fn wait_for_status_json(
         }
         std::thread::sleep(Duration::from_millis(100));
     }
+}
+
+#[test]
+fn grep_command_searches_contents_without_daemon() {
+    let vicaya_bin = PathBuf::from(env!("CARGO_BIN_EXE_vicaya"));
+    let vicaya_dir = tempfile::tempdir().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let file = corpus.path().join("src/main.rs");
+    write_file(&file, "fn main() {\n    println!(\"needle\");\n}\n");
+
+    let output = Command::new(&vicaya_bin)
+        .env("VICAYA_DIR", vicaya_dir.path())
+        .env("VICAYA_NO_UPDATE_CHECK", "1")
+        .args([
+            "grep",
+            "needle",
+            "--scope",
+            corpus.path().to_str().unwrap(),
+            "--engine",
+            "grep",
+            "--allow-slow-fallback",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "vicaya grep failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["engine"], "grep");
+    assert_eq!(
+        json["hits"][0]["path"].as_str(),
+        Some(file.to_string_lossy().as_ref())
+    );
+    assert_eq!(json["hits"][0]["line_number"], 2);
+
+    let other = corpus.path().join("src/other.rs");
+    write_file(&other, "needle outside file scope\n");
+    let file_scope = Command::new(&vicaya_bin)
+        .env("VICAYA_DIR", vicaya_dir.path())
+        .env("VICAYA_NO_UPDATE_CHECK", "1")
+        .args([
+            "grep",
+            "needle",
+            "--scope",
+            file.to_str().unwrap(),
+            "--engine",
+            "grep",
+            "--allow-slow-fallback",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        file_scope.status.success(),
+        "vicaya grep file scope failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&file_scope.stdout),
+        String::from_utf8_lossy(&file_scope.stderr)
+    );
+    let file_json: serde_json::Value = serde_json::from_slice(&file_scope.stdout).unwrap();
+    assert_eq!(file_json["hits"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        file_json["hits"][0]["path"].as_str(),
+        Some(file.to_string_lossy().as_ref())
+    );
 }
 
 #[test]

--- a/crates/vicaya-cli/tests/ranking_cli_smoke.rs
+++ b/crates/vicaya-cli/tests/ranking_cli_smoke.rs
@@ -94,6 +94,7 @@ fn cli_search_returns_json_results() {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
 
     std::fs::create_dir_all(vicaya_dir.path()).unwrap();

--- a/crates/vicaya-cli/tests/scope_cli_smoke.rs
+++ b/crates/vicaya-cli/tests/scope_cli_smoke.rs
@@ -87,6 +87,7 @@ fn cli_search_scope_restricts_results_to_requested_directory() {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
 
     std::fs::create_dir_all(vicaya_dir.path()).unwrap();

--- a/crates/vicaya-core/src/config.rs
+++ b/crates/vicaya-core/src/config.rs
@@ -28,6 +28,10 @@ pub struct Config {
     /// Smriti usage-memory settings.
     #[serde(default)]
     pub smriti: SmritiConfig,
+
+    /// Content search settings.
+    #[serde(default)]
+    pub content_search: ContentSearchConfig,
 }
 
 /// Performance-related configuration.
@@ -54,6 +58,37 @@ pub struct SmritiConfig {
     /// Maximum ranking boost applied to matching search results.
     #[serde(default = "default_smriti_max_boost")]
     pub max_boost: f32,
+}
+
+/// Content-search configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContentSearchConfig {
+    /// Whether content search is enabled.
+    #[serde(default = "default_content_search_enabled")]
+    pub enabled: bool,
+
+    /// Engine preference: auto, ripgrep, git-grep, or grep.
+    #[serde(default = "default_content_search_engine")]
+    pub engine: String,
+
+    /// Allow recursive grep fallback when ripgrep and git-grep are unavailable.
+    #[serde(default)]
+    pub allow_slow_fallback: bool,
+
+    /// Optional explicit ripgrep binary path.
+    #[serde(default)]
+    pub rg_path: Option<PathBuf>,
+}
+
+impl Default for ContentSearchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_content_search_enabled(),
+            engine: default_content_search_engine(),
+            allow_slow_fallback: false,
+            rg_path: None,
+        }
+    }
 }
 
 impl Default for SmritiConfig {
@@ -87,6 +122,7 @@ impl Default for Config {
                 reconcile_hour: 3,
             },
             smriti: SmritiConfig::default(),
+            content_search: ContentSearchConfig::default(),
         };
         config.normalize_exclusions();
         config
@@ -107,6 +143,14 @@ fn default_smriti_max_entries() -> usize {
 
 fn default_smriti_max_boost() -> f32 {
     0.08
+}
+
+fn default_content_search_enabled() -> bool {
+    true
+}
+
+fn default_content_search_engine() -> String {
+    "auto".to_string()
 }
 
 impl Config {
@@ -134,6 +178,10 @@ impl Config {
 
         // Expand in index_path
         self.index_path = Self::expand_path(&self.index_path);
+
+        if let Some(path) = self.content_search.rg_path.as_mut() {
+            *path = Self::expand_path(path);
+        }
     }
 
     fn normalize_exclusions(&mut self) {
@@ -177,6 +225,32 @@ impl Config {
     /// Whether Smriti is enabled after environment overrides.
     pub fn smriti_enabled(&self) -> bool {
         self.smriti.enabled && std::env::var_os("VICAYA_NO_SMRITI").is_none()
+    }
+
+    /// Whether content search is enabled after environment overrides.
+    pub fn content_search_enabled(&self) -> bool {
+        self.content_search.enabled && std::env::var_os("VICAYA_NO_CONTENT_SEARCH").is_none()
+    }
+
+    /// Configured content-search engine preference after environment overrides.
+    pub fn content_search_engine(
+        &self,
+    ) -> crate::Result<crate::content_search::ContentSearchEngineChoice> {
+        let engine = std::env::var("VICAYA_CONTENT_SEARCH_ENGINE")
+            .unwrap_or_else(|_| self.content_search.engine.clone());
+        crate::content_search::ContentSearchEngineChoice::parse(&engine)
+    }
+
+    /// Whether slow recursive grep fallback is allowed after environment overrides.
+    pub fn content_search_allow_slow_fallback(&self) -> bool {
+        if let Ok(value) = std::env::var("VICAYA_CONTENT_SEARCH_ALLOW_SLOW_FALLBACK") {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        } else {
+            self.content_search.allow_slow_fallback
+        }
     }
 }
 
@@ -254,11 +328,53 @@ reconcile_hour = 3
             PathBuf::from(format!("{home}/Projects"))
         );
         assert!(config.respect_ignore_files);
+        assert!(config.content_search_enabled());
+        assert_eq!(config.content_search.engine, "auto");
 
         // Verify tilde expansion in index_path
         assert_eq!(
             config.index_path,
             PathBuf::from(format!("{home}/Library/Application Support/vicaya"))
+        );
+    }
+
+    #[test]
+    fn test_content_search_config_expands_rg_path() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let home = env::var("HOME").unwrap();
+
+        let config_content = r#"
+index_roots = ["~/Documents"]
+exclusions = [".git"]
+index_path = "~/Library/Application Support/vicaya/index"
+max_memory_mb = 512
+
+[performance]
+scanner_threads = 4
+reconcile_hour = 3
+
+[content_search]
+enabled = true
+engine = "ripgrep"
+allow_slow_fallback = false
+rg_path = "~/bin/rg"
+"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(config_content.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = Config::load(temp_file.path()).unwrap();
+
+        assert_eq!(
+            config.content_search.rg_path,
+            Some(PathBuf::from(format!("{home}/bin/rg")))
+        );
+        assert_eq!(
+            config.content_search_engine().unwrap(),
+            crate::content_search::ContentSearchEngineChoice::Ripgrep
         );
     }
 
@@ -322,6 +438,7 @@ enabled = false
                 reconcile_hour: 2,
             },
             smriti: SmritiConfig::default(),
+            content_search: ContentSearchConfig::default(),
         };
 
         // Save

--- a/crates/vicaya-core/src/content_search.rs
+++ b/crates/vicaya-core/src/content_search.rs
@@ -1,0 +1,846 @@
+//! Content search powered by local grep-compatible tools.
+
+use crate::{Error, Result};
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+};
+
+/// User-facing engine selector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentSearchEngineChoice {
+    /// Pick the fastest available configured engine.
+    Auto,
+    /// Require ripgrep (`rg`) and fail if it is unavailable.
+    Ripgrep,
+    /// Require `git grep` in a git worktree.
+    GitGrep,
+    /// Require standard `grep`; callers should opt in because this can be slow.
+    Grep,
+}
+
+impl ContentSearchEngineChoice {
+    /// Parse a config/CLI engine value.
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "ripgrep" | "rg" => Ok(Self::Ripgrep),
+            "git-grep" | "git_grep" | "gitgrep" => Ok(Self::GitGrep),
+            "grep" => Ok(Self::Grep),
+            other => Err(Error::Config(format!(
+                "unknown content search engine '{other}'"
+            ))),
+        }
+    }
+}
+
+/// Concrete engine used for one search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContentSearchEngine {
+    /// ripgrep executed with JSON output.
+    Ripgrep,
+    /// `git grep` executed inside a repository.
+    GitGrep,
+    /// Standard grep executed over Vicaya-controlled traversal.
+    Grep,
+}
+
+impl ContentSearchEngine {
+    /// Return the stable user-facing label for this engine.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Ripgrep => "ripgrep",
+            Self::GitGrep => "git-grep",
+            Self::Grep => "grep",
+        }
+    }
+}
+
+/// One content match.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentSearchHit {
+    /// Absolute or scope-relative file path reported by the engine.
+    pub path: PathBuf,
+    /// One-based line number for the match.
+    pub line_number: usize,
+    /// One-based column number when the engine reports one.
+    pub column: Option<usize>,
+    /// Matched line text with trailing line endings removed.
+    pub line: String,
+}
+
+/// Search result bundle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentSearchReport {
+    /// Concrete engine that served this search.
+    pub engine: ContentSearchEngine,
+    /// Ordered content matches, capped by the requested limit.
+    pub hits: Vec<ContentSearchHit>,
+}
+
+/// Content search options.
+#[derive(Debug, Clone)]
+pub struct ContentSearchOptions {
+    /// Literal search text; empty queries return no hits.
+    pub query: String,
+    /// File or directory to search.
+    pub scope: PathBuf,
+    /// Maximum number of hits to return.
+    pub limit: usize,
+    /// Requested engine selection policy.
+    pub engine: ContentSearchEngineChoice,
+    /// Permit the explicit slow grep fallback in automatic mode.
+    pub allow_slow_fallback: bool,
+    /// Optional custom path to the `rg` binary.
+    pub rg_path: Option<PathBuf>,
+}
+
+impl ContentSearchOptions {
+    /// Build options with automatic engine selection and slow fallback disabled.
+    pub fn new(query: impl Into<String>, scope: impl Into<PathBuf>, limit: usize) -> Self {
+        Self {
+            query: query.into(),
+            scope: scope.into(),
+            limit,
+            engine: ContentSearchEngineChoice::Auto,
+            allow_slow_fallback: false,
+            rg_path: None,
+        }
+    }
+}
+
+/// Run content search with the best available configured engine.
+pub fn search(options: &ContentSearchOptions) -> Result<ContentSearchReport> {
+    let query = options.query.trim();
+    if query.is_empty() || options.limit == 0 {
+        let engine = resolve_engine(options)
+            .map(|resolved| resolved.engine)
+            .unwrap_or(ContentSearchEngine::Ripgrep);
+        return Ok(ContentSearchReport {
+            engine,
+            hits: Vec::new(),
+        });
+    }
+
+    let resolved = resolve_engine(options)?;
+    let hits = match resolved.engine {
+        ContentSearchEngine::Ripgrep => search_ripgrep(options, &resolved.command)?,
+        ContentSearchEngine::GitGrep => search_git_grep(options, &resolved.command)?,
+        ContentSearchEngine::Grep => search_grep(options, &resolved.command)?,
+    };
+
+    Ok(ContentSearchReport {
+        engine: resolved.engine,
+        hits,
+    })
+}
+
+struct ResolvedEngine {
+    engine: ContentSearchEngine,
+    command: PathBuf,
+}
+
+fn resolve_engine(options: &ContentSearchOptions) -> Result<ResolvedEngine> {
+    match options.engine {
+        ContentSearchEngineChoice::Ripgrep => {
+            let command = resolve_rg(options).ok_or_else(|| {
+                Error::Other("ripgrep is required for content search but 'rg' was not found".into())
+            })?;
+            Ok(ResolvedEngine {
+                engine: ContentSearchEngine::Ripgrep,
+                command,
+            })
+        }
+        ContentSearchEngineChoice::GitGrep => {
+            let command = find_command("git").ok_or_else(|| {
+                Error::Other("git-grep was requested but 'git' was not found".into())
+            })?;
+            ensure_git_scope(&options.scope, &command)?;
+            Ok(ResolvedEngine {
+                engine: ContentSearchEngine::GitGrep,
+                command,
+            })
+        }
+        ContentSearchEngineChoice::Grep => {
+            let command = find_command("grep").ok_or_else(|| {
+                Error::Other("grep was requested but 'grep' was not found".into())
+            })?;
+            Ok(ResolvedEngine {
+                engine: ContentSearchEngine::Grep,
+                command,
+            })
+        }
+        ContentSearchEngineChoice::Auto => {
+            if let Some(command) = resolve_rg(options) {
+                return Ok(ResolvedEngine {
+                    engine: ContentSearchEngine::Ripgrep,
+                    command,
+                });
+            }
+
+            if let Some(command) = find_command("git") {
+                if ensure_git_scope(&options.scope, &command).is_ok() {
+                    return Ok(ResolvedEngine {
+                        engine: ContentSearchEngine::GitGrep,
+                        command,
+                    });
+                }
+            }
+
+            if options.allow_slow_fallback {
+                if let Some(command) = find_command("grep") {
+                    return Ok(ResolvedEngine {
+                        engine: ContentSearchEngine::Grep,
+                        command,
+                    });
+                }
+            }
+
+            Err(Error::Other(
+                "content search unavailable: install ripgrep, run inside a git worktree for git-grep fallback, or enable the explicit slow grep fallback".into(),
+            ))
+        }
+    }
+}
+
+fn resolve_rg(options: &ContentSearchOptions) -> Option<PathBuf> {
+    options
+        .rg_path
+        .as_ref()
+        .filter(|path| is_executable(path))
+        .cloned()
+        .or_else(|| find_command("rg"))
+}
+
+fn find_command(name: &str) -> Option<PathBuf> {
+    let candidate = Path::new(name);
+    if candidate.components().count() > 1 {
+        return is_executable(candidate).then(|| candidate.to_path_buf());
+    }
+
+    std::env::var_os("PATH").and_then(|path| {
+        std::env::split_paths(&path)
+            .map(|dir| dir.join(name))
+            .find(|path| is_executable(path))
+    })
+}
+
+fn is_executable(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn search_ripgrep(options: &ContentSearchOptions, rg: &Path) -> Result<Vec<ContentSearchHit>> {
+    let mut command = Command::new(rg);
+    command
+        .arg("--json")
+        .arg("--fixed-strings")
+        .arg("--smart-case")
+        .arg("--color")
+        .arg("never")
+        .arg("--max-columns")
+        .arg("1000")
+        .arg("--max-filesize")
+        .arg("2M")
+        .arg("--")
+        .arg(&options.query)
+        .arg(&options.scope);
+
+    collect_json_rg(command, options.limit)
+}
+
+fn search_git_grep(options: &ContentSearchOptions, git: &Path) -> Result<Vec<ContentSearchHit>> {
+    let repo = git_repo_root(&options.scope, git)?;
+    let pathspec = scope_pathspec(&repo, &options.scope);
+
+    let mut command = Command::new(git);
+    command
+        .arg("-C")
+        .arg(&repo)
+        .arg("grep")
+        .arg("--untracked")
+        .arg("-n")
+        .arg("--column")
+        .arg("-I")
+        .arg("-F")
+        .arg("-e")
+        .arg(&options.query)
+        .arg("--");
+    if let Some(pathspec) = pathspec {
+        command.arg(pathspec);
+    }
+
+    collect_colon_matches(command, options.limit, Some(&repo), true)
+}
+
+fn search_grep(options: &ContentSearchOptions, grep: &Path) -> Result<Vec<ContentSearchHit>> {
+    let mut hits = Vec::with_capacity(options.limit.min(128));
+    let mut scanned = 0usize;
+    grep_scope(
+        grep,
+        &options.query,
+        &options.scope,
+        options.limit,
+        &mut scanned,
+        &mut hits,
+    )?;
+    Ok(hits)
+}
+
+fn collect_json_rg(mut command: Command, limit: usize) -> Result<Vec<ContentSearchHit>> {
+    let mut child = spawn_piped(&mut command)?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| Error::Other("failed to capture ripgrep output".into()))?;
+    let reader = BufReader::new(stdout);
+    let mut hits = Vec::with_capacity(limit.min(128));
+
+    for line in reader.lines() {
+        let line = line?;
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if value.get("type").and_then(|v| v.as_str()) != Some("match") {
+            continue;
+        }
+        let Some(data) = value.get("data") else {
+            continue;
+        };
+        let Some(path) = data
+            .get("path")
+            .and_then(|v| v.get("text"))
+            .and_then(|v| v.as_str())
+        else {
+            continue;
+        };
+        let line_number = data
+            .get("line_number")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        if line_number == 0 {
+            continue;
+        }
+        let text = data
+            .get("lines")
+            .and_then(|v| v.get("text"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let column = data
+            .get("submatches")
+            .and_then(|v| v.as_array())
+            .and_then(|items| items.first())
+            .and_then(|item| item.get("start"))
+            .and_then(|v| v.as_u64())
+            .map(|start| start as usize + 1);
+
+        hits.push(ContentSearchHit {
+            path: PathBuf::from(path),
+            line_number,
+            column,
+            line: clean_match_line(text),
+        });
+
+        if hits.len() >= limit {
+            terminate_child(&mut child);
+            return Ok(hits);
+        }
+    }
+
+    finish_child(child)?;
+    Ok(hits)
+}
+
+fn collect_colon_matches(
+    mut command: Command,
+    limit: usize,
+    base: Option<&Path>,
+    has_column: bool,
+) -> Result<Vec<ContentSearchHit>> {
+    let mut child = spawn_piped(&mut command)?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| Error::Other("failed to capture grep output".into()))?;
+    let reader = BufReader::new(stdout);
+    let mut hits = Vec::with_capacity(limit.min(128));
+
+    for line in reader.lines() {
+        let line = line?;
+        let Some(mut hit) = parse_colon_match(&line, has_column) else {
+            continue;
+        };
+        if let Some(base) = base {
+            if hit.path.is_relative() {
+                hit.path = base.join(&hit.path);
+            }
+        }
+        hits.push(hit);
+
+        if hits.len() >= limit {
+            terminate_child(&mut child);
+            return Ok(hits);
+        }
+    }
+
+    finish_child(child)?;
+    Ok(hits)
+}
+
+fn grep_scope(
+    grep: &Path,
+    query: &str,
+    path: &Path,
+    limit: usize,
+    scanned: &mut usize,
+    hits: &mut Vec<ContentSearchHit>,
+) -> Result<()> {
+    const MAX_GREP_FILES: usize = 20_000;
+
+    if hits.len() >= limit || *scanned >= MAX_GREP_FILES {
+        return Ok(());
+    }
+
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(_) => return Ok(()),
+    };
+
+    if meta.is_dir() {
+        if should_skip_grep_dir(path) {
+            return Ok(());
+        }
+        let entries = match std::fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(_) => return Ok(()),
+        };
+        for entry in entries.flatten() {
+            grep_scope(grep, query, &entry.path(), limit, scanned, hits)?;
+            if hits.len() >= limit || *scanned >= MAX_GREP_FILES {
+                break;
+            }
+        }
+        return Ok(());
+    }
+
+    if !meta.is_file() {
+        return Ok(());
+    }
+
+    *scanned += 1;
+    grep_file(grep, query, path, limit, hits)
+}
+
+fn should_skip_grep_dir(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    matches!(
+        name,
+        ".git"
+            | ".hg"
+            | ".svn"
+            | "target"
+            | "node_modules"
+            | ".cargo"
+            | ".rustup"
+            | ".shux"
+            | ".venv"
+            | "venv"
+            | "__pycache__"
+    )
+}
+
+fn grep_file(
+    grep: &Path,
+    query: &str,
+    path: &Path,
+    limit: usize,
+    hits: &mut Vec<ContentSearchHit>,
+) -> Result<()> {
+    let mut command = Command::new(grep);
+    command
+        .arg("-n")
+        .arg("-F")
+        .arg("-I")
+        .arg("--")
+        .arg(query)
+        .arg(path);
+
+    let mut child = spawn_piped(&mut command)?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| Error::Other("failed to capture grep output".into()))?;
+    let reader = BufReader::new(stdout);
+
+    for line in reader.lines() {
+        let line = line?;
+        let Some((line_number, text)) = parse_grep_file_line(&line) else {
+            continue;
+        };
+        hits.push(ContentSearchHit {
+            path: path.to_path_buf(),
+            line_number,
+            column: None,
+            line: clean_match_line(text),
+        });
+        if hits.len() >= limit {
+            terminate_child(&mut child);
+            return Ok(());
+        }
+    }
+
+    finish_child(child)
+}
+
+fn parse_grep_file_line(line: &str) -> Option<(usize, &str)> {
+    let (line_number, text) = line.split_once(':')?;
+    if line_number.is_empty() || !line_number.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some((line_number.parse().ok()?, text))
+}
+
+fn spawn_piped(command: &mut Command) -> Result<Child> {
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(Error::Io)
+}
+
+fn terminate_child(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn finish_child(mut child: Child) -> Result<()> {
+    let status = child.wait()?;
+    if status.success() || status.code() == Some(1) {
+        Ok(())
+    } else {
+        Err(Error::Other(format!("content search exited with {status}")))
+    }
+}
+
+fn parse_colon_match(line: &str, has_column: bool) -> Option<ContentSearchHit> {
+    if has_column {
+        return parse_colon_match_with_column(line);
+    }
+
+    let (path, line_number, rest) = split_numeric_field(line)?;
+    Some(ContentSearchHit {
+        path: PathBuf::from(path),
+        line_number,
+        column: None,
+        line: clean_match_line(rest),
+    })
+}
+
+fn parse_colon_match_with_column(line: &str) -> Option<ContentSearchHit> {
+    for (idx, ch) in line.char_indices() {
+        if ch != ':' {
+            continue;
+        }
+        let path = &line[..idx];
+        let rest = &line[idx + 1..];
+        let Some((line_number, rest)) = split_leading_number(rest) else {
+            continue;
+        };
+        let Some(rest) = rest.strip_prefix(':') else {
+            continue;
+        };
+        let Some((column, text)) = split_leading_number(rest) else {
+            continue;
+        };
+        let Some(text) = text.strip_prefix(':') else {
+            continue;
+        };
+
+        return Some(ContentSearchHit {
+            path: PathBuf::from(path),
+            line_number,
+            column: Some(column),
+            line: clean_match_line(text),
+        });
+    }
+
+    None
+}
+
+fn split_leading_number(input: &str) -> Option<(usize, &str)> {
+    let end = input
+        .char_indices()
+        .find_map(|(idx, ch)| (!ch.is_ascii_digit()).then_some(idx))
+        .unwrap_or(input.len());
+    if end == 0 {
+        return None;
+    }
+    Some((input[..end].parse().ok()?, &input[end..]))
+}
+
+fn split_numeric_field(input: &str) -> Option<(&str, usize, &str)> {
+    for (idx, ch) in input.char_indices() {
+        if ch != ':' {
+            continue;
+        }
+        let rest = &input[idx + 1..];
+        let next_colon = rest.find(':')?;
+        let number = &rest[..next_colon];
+        if number.is_empty() || !number.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        let parsed = number.parse().ok()?;
+        return Some((&input[..idx], parsed, &rest[next_colon + 1..]));
+    }
+
+    None
+}
+
+fn clean_match_line(line: &str) -> String {
+    line.trim_end_matches(['\r', '\n']).to_string()
+}
+
+fn ensure_git_scope(scope: &Path, git: &Path) -> Result<()> {
+    git_repo_root(scope, git).map(|_| ())
+}
+
+fn git_repo_root(scope: &Path, git: &Path) -> Result<PathBuf> {
+    let cwd = if scope.is_file() {
+        scope.parent().unwrap_or(scope)
+    } else {
+        scope
+    };
+    let output = Command::new(git)
+        .arg("-C")
+        .arg(cwd)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::Other("scope is not inside a git worktree".into()));
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    let root = text.trim();
+    if root.is_empty() {
+        Err(Error::Other("git worktree root was empty".into()))
+    } else {
+        Ok(PathBuf::from(root))
+    }
+}
+
+fn scope_pathspec(repo: &Path, scope: &Path) -> Option<PathBuf> {
+    let canonical_repo = std::fs::canonicalize(repo).ok()?;
+    let canonical_scope = std::fs::canonicalize(scope).ok()?;
+    if canonical_scope == canonical_repo {
+        return None;
+    }
+    canonical_scope
+        .strip_prefix(canonical_repo)
+        .ok()
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+fn command_exists_for_tests(name: &str) -> bool {
+    find_command(name).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn normalize_test_path(path: &Path) -> PathBuf {
+        let raw = path.to_string_lossy();
+        raw.strip_prefix("/private/var/")
+            .map(|suffix| PathBuf::from(format!("/var/{suffix}")))
+            .unwrap_or_else(|| path.to_path_buf())
+    }
+
+    #[test]
+    fn parses_engine_aliases() {
+        assert_eq!(
+            ContentSearchEngineChoice::parse("rg").unwrap(),
+            ContentSearchEngineChoice::Ripgrep
+        );
+        assert_eq!(
+            ContentSearchEngineChoice::parse("git_grep").unwrap(),
+            ContentSearchEngineChoice::GitGrep
+        );
+        assert!(ContentSearchEngineChoice::parse("ack").is_err());
+    }
+
+    #[test]
+    fn parses_git_grep_line_with_colons_in_path() {
+        let hit = parse_colon_match("src/a:b.rs:12:8:let needle = true;", true).unwrap();
+        assert_eq!(hit.path, PathBuf::from("src/a:b.rs"));
+        assert_eq!(hit.line_number, 12);
+        assert_eq!(hit.column, Some(8));
+        assert_eq!(hit.line, "let needle = true;");
+    }
+
+    #[test]
+    fn parses_git_grep_line_with_digit_colon_in_path() {
+        let hit = parse_colon_match("src/foo:12:bar.rs:5:1:needle", true).unwrap();
+        assert_eq!(hit.path, PathBuf::from("src/foo:12:bar.rs"));
+        assert_eq!(hit.line_number, 5);
+        assert_eq!(hit.column, Some(1));
+        assert_eq!(hit.line, "needle");
+    }
+
+    #[test]
+    fn parses_git_grep_line_before_numeric_colons_in_match_text() {
+        let hit = parse_colon_match("src/main.rs:5:1:error code: 12:3: later", true).unwrap();
+        assert_eq!(hit.path, PathBuf::from("src/main.rs"));
+        assert_eq!(hit.line_number, 5);
+        assert_eq!(hit.column, Some(1));
+        assert_eq!(hit.line, "error code: 12:3: later");
+    }
+
+    #[test]
+    fn parses_plain_grep_line() {
+        let hit = parse_colon_match("/tmp/demo.rs:3:fn main() {}", false).unwrap();
+        assert_eq!(hit.path, PathBuf::from("/tmp/demo.rs"));
+        assert_eq!(hit.line_number, 3);
+        assert_eq!(hit.column, None);
+        assert_eq!(hit.line, "fn main() {}");
+    }
+
+    #[test]
+    fn returns_empty_hits_for_empty_query() {
+        let mut options = ContentSearchOptions::new("", ".", 10);
+        options.engine = ContentSearchEngineChoice::Grep;
+        let report = search(&options).unwrap();
+        assert_eq!(report.engine, ContentSearchEngine::Grep);
+        assert!(report.hits.is_empty());
+    }
+
+    #[test]
+    fn grep_engine_finds_literal_matches_when_requested() {
+        if !command_exists_for_tests("grep") {
+            return;
+        }
+
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("note.txt");
+        let mut f = std::fs::File::create(&file).unwrap();
+        writeln!(f, "first").unwrap();
+        writeln!(f, "needle here").unwrap();
+
+        let mut options = ContentSearchOptions::new("needle", dir.path(), 10);
+        options.engine = ContentSearchEngineChoice::Grep;
+        let report = search(&options).unwrap();
+
+        assert_eq!(report.engine, ContentSearchEngine::Grep);
+        assert_eq!(report.hits.len(), 1);
+        assert_eq!(
+            normalize_test_path(&report.hits[0].path),
+            normalize_test_path(&file)
+        );
+        assert_eq!(report.hits[0].line_number, 2);
+    }
+
+    #[test]
+    fn grep_engine_skips_heavy_dirs_and_stops_at_limit() {
+        if !command_exists_for_tests("grep") {
+            return;
+        }
+
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+        std::fs::write(dir.path().join(".git/ignored.txt"), "needle in metadata").unwrap();
+        let visible = dir.path().join("visible.txt");
+        std::fs::write(&visible, "needle in visible file\nneedle again").unwrap();
+
+        let mut options = ContentSearchOptions::new("needle", dir.path(), 1);
+        options.engine = ContentSearchEngineChoice::Grep;
+        let report = search(&options).unwrap();
+
+        assert_eq!(report.engine, ContentSearchEngine::Grep);
+        assert_eq!(report.hits.len(), 1);
+        assert_eq!(report.hits[0].path, visible);
+        assert_eq!(report.hits[0].line, "needle in visible file");
+    }
+
+    #[test]
+    fn git_grep_engine_finds_untracked_matches_with_colon_path() {
+        if !command_exists_for_tests("git") {
+            return;
+        }
+
+        let dir = tempdir().unwrap();
+        let init = Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .arg("init")
+            .output()
+            .unwrap();
+        if !init.status.success() {
+            return;
+        }
+
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        let file = src.join("foo:12:bar.rs");
+        std::fs::write(&file, "fn main() {}\nlet needle = true;\n").unwrap();
+
+        let mut options = ContentSearchOptions::new("needle", dir.path(), 10);
+        options.engine = ContentSearchEngineChoice::GitGrep;
+        let report = search(&options).unwrap();
+
+        assert_eq!(report.engine, ContentSearchEngine::GitGrep);
+        assert_eq!(report.hits.len(), 1);
+        assert_eq!(
+            normalize_test_path(&report.hits[0].path),
+            normalize_test_path(&file)
+        );
+        assert_eq!(report.hits[0].line_number, 2);
+        assert_eq!(report.hits[0].column, Some(5));
+    }
+
+    #[test]
+    fn ripgrep_engine_finds_matches_when_available() {
+        if !command_exists_for_tests("rg") {
+            return;
+        }
+
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("main.rs");
+        std::fs::write(&file, "fn main() {\n    let needle = true;\n}\n").unwrap();
+
+        let mut options = ContentSearchOptions::new("needle", dir.path(), 10);
+        options.engine = ContentSearchEngineChoice::Ripgrep;
+        let report = search(&options).unwrap();
+
+        assert_eq!(report.engine, ContentSearchEngine::Ripgrep);
+        assert_eq!(report.hits.len(), 1);
+        assert_eq!(
+            normalize_test_path(&report.hits[0].path),
+            normalize_test_path(&file)
+        );
+        assert_eq!(report.hits[0].line_number, 2);
+        assert_eq!(report.hits[0].column, Some(9));
+    }
+}

--- a/crates/vicaya-core/src/lib.rs
+++ b/crates/vicaya-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod build_info;
 pub mod config;
+pub mod content_search;
 pub mod daemon;
 pub mod error;
 pub mod filter;

--- a/crates/vicaya-daemon/src/ipc_server.rs
+++ b/crates/vicaya-daemon/src/ipc_server.rs
@@ -1522,7 +1522,7 @@ impl Drop for IpcServer {
 mod tests {
     use super::*;
     use tempfile::tempdir;
-    use vicaya_core::config::{PerformanceConfig, SmritiConfig};
+    use vicaya_core::config::{ContentSearchConfig, PerformanceConfig, SmritiConfig};
     use vicaya_scanner::Scanner;
 
     fn test_config(root: &Path, vicaya_dir: &Path) -> Config {
@@ -1537,6 +1537,7 @@ mod tests {
                 reconcile_hour: 3,
             },
             smriti: SmritiConfig::default(),
+            content_search: ContentSearchConfig::default(),
         }
     }
 

--- a/crates/vicaya-daemon/src/main.rs
+++ b/crates/vicaya-daemon/src/main.rs
@@ -377,6 +377,7 @@ mod tests {
                 reconcile_hour: 3,
             },
             smriti: vicaya_core::config::SmritiConfig::default(),
+            content_search: vicaya_core::config::ContentSearchConfig::default(),
         }
     }
 

--- a/crates/vicaya-daemon/tests/filter_scope.rs
+++ b/crates/vicaya-daemon/tests/filter_scope.rs
@@ -67,6 +67,7 @@ fn daemon_search_filter_scope_restricts_results_before_limit() {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
 
     std::fs::create_dir_all(vicaya_dir.path()).unwrap();

--- a/crates/vicaya-daemon/tests/ipc_large_response.rs
+++ b/crates/vicaya-daemon/tests/ipc_large_response.rs
@@ -69,6 +69,7 @@ fn it_handles_large_search_responses_without_truncation() {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
 
     std::fs::create_dir_all(vicaya_dir.path()).unwrap();
@@ -142,6 +143,7 @@ fn it_rejects_oversized_requests_and_stays_responsive() {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
 
     std::fs::create_dir_all(vicaya_dir.path()).unwrap();

--- a/crates/vicaya-daemon/tests/startup_reconcile.rs
+++ b/crates/vicaya-daemon/tests/startup_reconcile.rs
@@ -88,6 +88,7 @@ fn it_indexes_offline_changes_via_startup_reconcile() {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
 
     std::fs::create_dir_all(vicaya_dir.path()).unwrap();
@@ -164,6 +165,7 @@ fn it_replays_journal_when_starting_from_existing_index() {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
 
     std::fs::create_dir_all(vicaya_dir.path()).unwrap();
@@ -244,6 +246,7 @@ fn it_discards_stale_journal_when_starting_from_fresh_build() {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     };
 
     std::fs::create_dir_all(vicaya_dir.path()).unwrap();

--- a/crates/vicaya-scanner/src/lib.rs
+++ b/crates/vicaya-scanner/src/lib.rs
@@ -346,6 +346,7 @@ mod tests {
                 reconcile_hour: 3,
             },
             smriti: vicaya_core::config::SmritiConfig::default(),
+            content_search: vicaya_core::config::ContentSearchConfig::default(),
         }
     }
 

--- a/crates/vicaya-scanner/tests/search_correctness.rs
+++ b/crates/vicaya-scanner/tests/search_correctness.rs
@@ -23,6 +23,7 @@ fn create_test_config(root: &Path) -> Config {
             reconcile_hour: 3,
         },
         smriti: vicaya_core::config::SmritiConfig::default(),
+        content_search: vicaya_core::config::ContentSearchConfig::default(),
     }
 }
 

--- a/crates/vicaya-tui/src/app.rs
+++ b/crates/vicaya-tui/src/app.rs
@@ -139,6 +139,7 @@ fn run_app<B: ratatui::backend::Backend>(
                     title,
                     lines,
                     truncated,
+                    anchor_line,
                 } => {
                     if id == active_preview_id {
                         app.preview.is_loading = false;
@@ -148,6 +149,9 @@ fn run_app<B: ratatui::backend::Backend>(
                         app.preview.lines = lines;
                         app.preview.content_line_numbers =
                             crate::state::compute_content_line_numbers(&app.preview.lines);
+                        if let Some(line) = anchor_line {
+                            app.preview.scroll = preview_scroll_for_line(app, line);
+                        }
                     }
                 }
             }
@@ -214,10 +218,14 @@ fn run_app<B: ratatui::backend::Backend>(
         // Schedule preview for selected result (best-effort).
         if app.preview.is_visible && app.mode == AppMode::Search {
             if let Some(result) = app.search.selected_result() {
-                if last_preview_path.as_deref() != Some(result.path.as_str()) {
+                let anchor_line = content_result_anchor(app.view, result);
+                let preview_key = anchor_line
+                    .map(|line| format!("{}#{line}", result.path))
+                    .unwrap_or_else(|| result.path.clone());
+                if last_preview_path.as_deref() != Some(preview_key.as_str()) {
                     preview_id = preview_id.wrapping_add(1);
                     active_preview_id = preview_id;
-                    last_preview_path = Some(result.path.clone());
+                    last_preview_path = Some(preview_key);
                     app.preview.is_loading = true;
                     app.preview.truncated = false;
                     app.preview.path = Some(result.path.clone());
@@ -225,9 +233,16 @@ fn run_app<B: ratatui::backend::Backend>(
                     app.preview.lines.clear();
                     app.preview.content_line_numbers.clear();
                     app.preview.scroll = 0;
+                    if anchor_line.is_some() {
+                        app.preview.search_query =
+                            crate::state::parse_query(&app.search.query).term;
+                    } else if app.view != crate::state::ViewKind::Antarvicaya {
+                        app.preview.clear_search();
+                    }
                     let _ = cmd_tx.send(WorkerCommand::Preview {
                         id: active_preview_id,
                         path: result.path.clone(),
+                        anchor_line,
                     });
                 }
             } else if last_preview_path.is_some() {
@@ -260,6 +275,31 @@ fn run_app<B: ratatui::backend::Backend>(
     }
 
     Ok(())
+}
+
+fn content_result_anchor(
+    view: crate::state::ViewKind,
+    result: &vicaya_index::SearchResult,
+) -> Option<usize> {
+    if view != crate::state::ViewKind::Antarvicaya {
+        return None;
+    }
+
+    let file_name = std::path::Path::new(&result.path)
+        .file_name()
+        .and_then(|name| name.to_str())?;
+    let rest = result.name.strip_prefix(file_name)?.strip_prefix(':')?;
+    rest.split(':').next()?.parse().ok()
+}
+
+fn preview_scroll_for_line(app: &AppState, line: usize) -> u16 {
+    let target = app
+        .preview
+        .content_line_numbers
+        .iter()
+        .position(|number| *number == Some(line))
+        .unwrap_or(0);
+    target.saturating_sub(3) as u16
 }
 
 /// Handle keyboard events
@@ -1290,6 +1330,41 @@ mod tests {
         handle_key_event(&mut app, KeyCode::Char('p'), KeyModifiers::NONE);
         assert_eq!(app.print_on_exit, Some(file.to_string_lossy().to_string()));
         assert!(app.should_quit());
+    }
+
+    #[test]
+    fn content_result_anchor_parses_line_from_result_name() {
+        let result = SearchResult {
+            path: "/tmp/project/src/main.rs".to_string(),
+            name: "main.rs:42:7  fn main() {}".to_string(),
+            score: 1.0,
+            size: 0,
+            mtime: 0,
+        };
+
+        assert_eq!(
+            content_result_anchor(ViewKind::Antarvicaya, &result),
+            Some(42)
+        );
+        assert_eq!(content_result_anchor(ViewKind::Patra, &result), None);
+    }
+
+    #[test]
+    fn preview_scroll_for_line_keeps_match_near_top() {
+        let mut app = AppState::new();
+        app.preview.lines = vec![
+            meta_line("/tmp/file.rs"),
+            meta_line("10 bytes"),
+            meta_line(""),
+            plain_line("one"),
+            plain_line("two"),
+            plain_line("three"),
+            plain_line("four"),
+        ];
+        app.preview.content_line_numbers =
+            crate::state::compute_content_line_numbers(&app.preview.lines);
+
+        assert_eq!(preview_scroll_for_line(&app, 4), 3);
     }
 
     #[test]

--- a/crates/vicaya-tui/src/state/mod.rs
+++ b/crates/vicaya-tui/src/state/mod.rs
@@ -513,7 +513,10 @@ impl ViewKind {
     }
 
     pub fn is_enabled(self) -> bool {
-        matches!(self, ViewKind::Patra | ViewKind::Sthana | ViewKind::Smriti)
+        matches!(
+            self,
+            ViewKind::Patra | ViewKind::Sthana | ViewKind::Smriti | ViewKind::Antarvicaya
+        )
     }
 }
 

--- a/crates/vicaya-tui/src/ui/results.rs
+++ b/crates/vicaya-tui/src/ui/results.rs
@@ -34,72 +34,76 @@ pub fn render(f: &mut Frame, area: Rect, app: &mut AppState) {
     let available_width = area.width.saturating_sub(4); // Account for borders
     let max_path_len = available_width.saturating_sub(30) as usize; // Reserve space for name, score, marker
 
-    let items: Vec<ListItem> = rows[start..end]
-        .iter()
-        .map(|row| match row {
-            RenderRow::Header(label) => {
-                let line = Line::from(vec![
-                    Span::styled("┈ ", Style::default().fg(ui::TEXT_MUTED)),
-                    Span::styled(
-                        label,
+    let items: Vec<ListItem> = if rows.is_empty() {
+        empty_rows(app)
+    } else {
+        rows[start..end]
+            .iter()
+            .map(|row| match row {
+                RenderRow::Header(label) => {
+                    let line = Line::from(vec![
+                        Span::styled("┈ ", Style::default().fg(ui::TEXT_MUTED)),
+                        Span::styled(
+                            label,
+                            Style::default()
+                                .fg(ui::TEXT_SECONDARY)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]);
+                    ListItem::new(line).style(Style::default())
+                }
+                RenderRow::Result(result_index) => {
+                    let result = &results[*result_index];
+                    let marker = if *result_index == selected {
+                        "▸"
+                    } else {
+                        " "
+                    };
+                    let score_color = ui::score_color(result.score);
+                    let is_selected = *result_index == selected;
+
+                    let path = std::path::Path::new(&result.path);
+                    let dir_path = path.parent().and_then(|p| p.to_str()).unwrap_or("");
+
+                    // Truncate path if not selected
+                    let display_path = truncate_path(dir_path, max_path_len.max(30), is_selected);
+
+                    let mut spans = vec![
+                        Span::styled(marker, Style::default().fg(ui::PRIMARY)),
+                        Span::raw(" "),
+                    ];
+
+                    let (name, name_style) = if app.view == crate::state::ViewKind::Sthana {
+                        (format!("{}/", result.name), Style::default().fg(ui::ACCENT))
+                    } else {
+                        (result.name.clone(), Style::default().fg(ui::TEXT_PRIMARY))
+                    };
+
+                    spans.extend(vec![
+                        Span::styled(name, name_style),
+                        Span::raw(" "),
+                        Span::styled(
+                            format!("({}) ", display_path),
+                            Style::default().fg(ui::TEXT_MUTED),
+                        ),
+                        Span::styled(
+                            format!("{:.2}", result.score),
+                            Style::default().fg(score_color),
+                        ),
+                    ]);
+
+                    let line = Line::from(spans);
+                    let style = if is_selected {
+                        Style::default().bg(ui::BG_ELEVATED)
+                    } else {
                         Style::default()
-                            .fg(ui::TEXT_SECONDARY)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                ]);
-                ListItem::new(line).style(Style::default())
-            }
-            RenderRow::Result(result_index) => {
-                let result = &results[*result_index];
-                let marker = if *result_index == selected {
-                    "▸"
-                } else {
-                    " "
-                };
-                let score_color = ui::score_color(result.score);
-                let is_selected = *result_index == selected;
+                    };
 
-                let path = std::path::Path::new(&result.path);
-                let dir_path = path.parent().and_then(|p| p.to_str()).unwrap_or("");
-
-                // Truncate path if not selected
-                let display_path = truncate_path(dir_path, max_path_len.max(30), is_selected);
-
-                let mut spans = vec![
-                    Span::styled(marker, Style::default().fg(ui::PRIMARY)),
-                    Span::raw(" "),
-                ];
-
-                let (name, name_style) = if app.view == crate::state::ViewKind::Sthana {
-                    (format!("{}/", result.name), Style::default().fg(ui::ACCENT))
-                } else {
-                    (result.name.clone(), Style::default().fg(ui::TEXT_PRIMARY))
-                };
-
-                spans.extend(vec![
-                    Span::styled(name, name_style),
-                    Span::raw(" "),
-                    Span::styled(
-                        format!("({}) ", display_path),
-                        Style::default().fg(ui::TEXT_MUTED),
-                    ),
-                    Span::styled(
-                        format!("{:.2}", result.score),
-                        Style::default().fg(score_color),
-                    ),
-                ]);
-
-                let line = Line::from(spans);
-                let style = if is_selected {
-                    Style::default().bg(ui::BG_ELEVATED)
-                } else {
-                    Style::default()
-                };
-
-                ListItem::new(line).style(style)
-            }
-        })
-        .collect();
+                    ListItem::new(line).style(style)
+                }
+            })
+            .collect()
+    };
 
     let border_style = if app.search.is_results_focused() {
         Style::default().fg(ui::BORDER_FOCUS)
@@ -130,6 +134,20 @@ pub fn render(f: &mut Frame, area: Rect, app: &mut AppState) {
     );
 
     f.render_widget(list.style(Style::default().bg(ui::BG_SURFACE)), area);
+}
+
+fn empty_rows(app: &AppState) -> Vec<ListItem<'static>> {
+    if let Some(error) = app.error.as_ref().filter(|msg| !msg.starts_with('✓')) {
+        return vec![ListItem::new(Line::from(vec![
+            Span::styled("! ", Style::default().fg(ui::ERROR)),
+            Span::styled(
+                error.clone(),
+                Style::default().fg(ui::ERROR).add_modifier(Modifier::BOLD),
+            ),
+        ]))];
+    }
+
+    Vec::new()
 }
 
 fn build_rows(app: &AppState) -> (Vec<RenderRow>, usize) {

--- a/crates/vicaya-tui/src/worker.rs
+++ b/crates/vicaya-tui/src/worker.rs
@@ -4,6 +4,7 @@ use crate::client::{DaemonStatus, IpcClient};
 use crate::state::{Niyama, NiyamaType, StyledLine, StyledSegment, TextKind, TextStyle, ViewKind};
 use std::sync::mpsc::{Receiver, Sender};
 use std::time::Duration;
+use vicaya_core::content_search::{ContentSearchOptions, ContentSearchReport};
 use vicaya_core::smriti::SmritiAction;
 use vicaya_index::SearchResult;
 
@@ -39,6 +40,7 @@ pub enum WorkerCommand {
     Preview {
         id: u64,
         path: String,
+        anchor_line: Option<usize>,
     },
     RecordSmriti {
         path: String,
@@ -63,6 +65,7 @@ pub enum WorkerEvent {
         title: String,
         lines: Vec<StyledLine>,
         truncated: bool,
+        anchor_line: Option<usize>,
     },
     Status {
         status: Option<DaemonStatus>,
@@ -97,7 +100,7 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
     }
 
     let mut pending_search: Option<PendingSearch> = None;
-    let mut pending_preview: Option<(u64, String)> = None;
+    let mut pending_preview: Option<(u64, String, Option<usize>)> = None;
 
     'worker: loop {
         // Receive at least one command, but wake periodically for status.
@@ -122,7 +125,11 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
                         niyamas,
                     })
                 }
-                WorkerCommand::Preview { id, path } => pending_preview = Some((id, path)),
+                WorkerCommand::Preview {
+                    id,
+                    path,
+                    anchor_line,
+                } => pending_preview = Some((id, path, anchor_line)),
                 WorkerCommand::RecordSmriti {
                     path,
                     query,
@@ -161,7 +168,11 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
                         niyamas,
                     })
                 }
-                WorkerCommand::Preview { id, path } => pending_preview = Some((id, path)),
+                WorkerCommand::Preview {
+                    id,
+                    path,
+                    anchor_line,
+                } => pending_preview = Some((id, path, anchor_line)),
                 WorkerCommand::RecordSmriti {
                     path,
                     query,
@@ -219,6 +230,18 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
                         continue;
                     }
                 }
+            } else if view == ViewKind::Antarvicaya {
+                match content_search_results(&trimmed, limit, filter_scope.or(boost_scope)) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = evt_tx.send(WorkerEvent::SearchResults {
+                            id,
+                            results: Vec::new(),
+                            error: Some(format!("Content search error: {}", e)),
+                        });
+                        continue;
+                    }
+                }
             } else {
                 match search_client.search(
                     &trimmed,
@@ -250,7 +273,7 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
             });
         }
 
-        if let Some((id, path)) = pending_preview.take() {
+        if let Some((id, path, anchor_line)) = pending_preview.take() {
             let (title, lines, truncated, error) = build_preview(&path, &syntaxes, theme);
             let _ = evt_tx.send(WorkerEvent::PreviewReady {
                 id,
@@ -258,6 +281,7 @@ fn worker_loop(cmd_rx: Receiver<WorkerCommand>, evt_tx: Sender<WorkerEvent>) {
                 title,
                 lines,
                 truncated,
+                anchor_line,
             });
             if let Some(error) = error {
                 tracing::debug!("Preview error: {}", error);
@@ -383,6 +407,88 @@ fn matches_filters(
     }
 
     true
+}
+
+fn content_search_results(
+    query: &str,
+    limit: usize,
+    scope: Option<&std::path::Path>,
+) -> anyhow::Result<Vec<SearchResult>> {
+    let config = load_config_for_worker()?;
+    if !config.content_search_enabled() {
+        anyhow::bail!("content search is disabled");
+    }
+
+    let scope = scope
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or(std::env::current_dir()?);
+    let mut options = ContentSearchOptions::new(query, scope, limit);
+    options.engine = config.content_search_engine()?;
+    options.allow_slow_fallback = config.content_search_allow_slow_fallback();
+    options.rg_path = config.content_search.rg_path.clone();
+
+    let report = vicaya_core::content_search::search(&options)?;
+    Ok(report_to_search_results(report, limit))
+}
+
+fn load_config_for_worker() -> anyhow::Result<vicaya_core::Config> {
+    let config_path = vicaya_core::paths::config_path();
+    if config_path.exists() {
+        Ok(vicaya_core::Config::load(&config_path)?)
+    } else {
+        Ok(vicaya_core::Config::default())
+    }
+}
+
+fn report_to_search_results(report: ContentSearchReport, limit: usize) -> Vec<SearchResult> {
+    let total = report.hits.len().max(1) as f32;
+    report
+        .hits
+        .into_iter()
+        .take(limit)
+        .enumerate()
+        .map(|(idx, hit)| {
+            let meta = std::fs::metadata(&hit.path).ok();
+            let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
+            let mtime = meta
+                .and_then(|m| m.modified().ok())
+                .and_then(|mtime| mtime.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|duration| duration.as_secs() as i64)
+                .unwrap_or(0);
+            let file_name = hit
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_else(|| hit.path.to_str().unwrap_or("(match)"));
+            let column = hit.column.unwrap_or(1);
+            let snippet = truncate_snippet(&hit.line, 96);
+
+            SearchResult {
+                path: hit.path.to_string_lossy().to_string(),
+                name: format!("{}:{}:{}  {}", file_name, hit.line_number, column, snippet),
+                score: (1.0 - (idx as f32 / total) * 0.25).max(0.01),
+                size,
+                mtime,
+            }
+        })
+        .collect()
+}
+
+fn truncate_snippet(text: &str, max_chars: usize) -> String {
+    let trimmed = text.trim();
+    let mut out = String::new();
+    for (idx, ch) in trimmed.chars().enumerate() {
+        if idx >= max_chars {
+            out.push_str("...");
+            return out;
+        }
+        if ch.is_control() {
+            out.push(' ');
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 fn pick_theme(themes: &ThemeSet) -> &Theme {
@@ -763,6 +869,29 @@ mod tests {
             Some(dir.path()),
             &ext_rs
         ));
+    }
+
+    #[test]
+    fn content_report_maps_hits_to_tui_rows() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("main.rs");
+        std::fs::write(&file_path, "fn main() {}\n").unwrap();
+
+        let report = ContentSearchReport {
+            engine: vicaya_core::content_search::ContentSearchEngine::Ripgrep,
+            hits: vec![vicaya_core::content_search::ContentSearchHit {
+                path: file_path.clone(),
+                line_number: 1,
+                column: Some(4),
+                line: "fn main() {}".to_string(),
+            }],
+        };
+
+        let results = report_to_search_results(report, 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, file_path.to_string_lossy());
+        assert_eq!(results[0].name, "main.rs:1:4  fn main() {}");
+        assert_eq!(results[0].size, 13);
     }
 
     #[test]
@@ -1158,6 +1287,7 @@ mod tests {
             .send(WorkerCommand::Preview {
                 id: 9,
                 path: preview_file.to_string_lossy().to_string(),
+                anchor_line: None,
             })
             .unwrap();
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,13 +65,13 @@ sub-20ms query latency over millions of files.
 
 | Crate | Purpose | Binary? |
 |---|---|---|
-| `vicaya-core` | Config, logging, error types, IPC protocol, path utilities, filter rules | No (lib) |
+| `vicaya-core` | Config, logging, error types, IPC protocol, path utilities, filter rules, content-search engine selection | No (lib) |
 | `vicaya-index` | FileTable, StringArena, TrigramIndex, QueryEngine, AbbreviationMatcher | No (lib) |
 | `vicaya-scanner` | Filesystem walker (walkdir/rayon), builds `IndexSnapshot` | No (lib) |
 | `vicaya-watcher` | FSEvents wrapper (notify crate), emits `IndexUpdate` events | No (lib) |
 | `vicaya-daemon` | Background service: loads index, handles IPC, applies live updates | Yes |
-| `vicaya-cli` | CLI binary (`vicaya`): search, rebuild, daemon control, metrics | Yes |
-| `vicaya-tui` | Terminal UI (`vicaya-tui`): streaming search with preview pane | Yes |
+| `vicaya-cli` | CLI binary (`vicaya`): search, grep, rebuild, daemon control, metrics | Yes |
+| `vicaya-tui` | Terminal UI (`vicaya-tui`): streaming search/content drishtis with preview pane | Yes |
 
 ## Crate Dependencies
 
@@ -649,14 +649,14 @@ ones in the burst are discarded.
 
 The worker thread handles all I/O off the main thread:
 
-**Commands** (main → worker):
-- `Search { id, query, limit, view, boost_scope, filter_scope, niyamas }` — Execute search via daemon IPC
-- `Preview { id, path }` — Load and syntax-highlight file preview
+**Commands** (main -> worker):
+- `Search { id, query, limit, view, boost_scope, filter_scope, niyamas }` — Execute filename search via daemon IPC, Smriti search via daemon IPC, or scoped content search locally for `Antarvicaya`
+- `Preview { id, path, anchor_line }` — Load and syntax-highlight file preview, optionally centered near a content match
 - `Quit` — Shut down worker
 
-**Events** (worker → main):
+**Events** (worker -> main):
 - `SearchResults { id, results, error }` — Search completed
-- `PreviewReady { id, path, title, lines, truncated }` — Preview loaded
+- `PreviewReady { id, path, title, lines, truncated, anchor_line }` — Preview loaded
 - `Status { status }` — Periodic daemon status update
 
 Both search and preview use incrementing IDs so the main loop can discard
@@ -778,6 +778,18 @@ updates. The daily reconciliation resets the journal, bounding its size.
 - Trigrams are extracted only from basenames, keeping the index compact
 - `respect_ignore_files = false` disables repository ignore-file handling; this
   changes index membership and requires a rebuild
+
+### Content Search
+
+- Content search is deliberately not indexed. `vicaya grep` and the TUI
+  `Antarvicaya` drishti run scoped, local process searches through
+  `vicaya-core::content_search`.
+- Engine policy is fast first: `rg` when available, then `git grep` inside a git
+  worktree, then plain recursive `grep` only when requested or when
+  `[content_search] allow_slow_fallback = true`.
+- TUI rows encode `file:line:column` plus a compact snippet. The preview pane
+  jumps near the selected match and reuses the existing syntax-highlighted file
+  preview path.
 
 ### IPC
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -43,6 +43,27 @@ daemon, and runs `hyperfine` against home, current-repo, sibling-repo, and
 `smriti list` commands. The seed step is intentional: the benchmark exercises
 populated usage-memory ranking rather than only the empty-store fast path.
 
+## 2026-05-27 Content Search Drishti Snapshot
+
+Branch-local `hyperfine` runs used release binaries, an isolated
+`VICAYA_DIR`, and a branch-local daemon indexed to this checkout. Artifacts:
+`.shux/out/content-search/hyperfine-content-search.json` and
+`.shux/out/content-search/hyperfine-daemon-status-before.json`.
+
+| Command Shape | Mean Time |
+| --- | --- |
+| `vicaya search "main.rs" --scope <repo> --limit 20` | `6.7 ms ± 1.5 ms` |
+| `vicaya grep "fn main" --scope <repo> --limit 20` | `13.4 ms ± 3.1 ms` |
+| `VICAYA_CONTENT_SEARCH_ENGINE=git-grep vicaya grep "content search" --scope <repo> --limit 20` | `23.1 ms ± 1.5 ms` |
+
+Key takeaways:
+
+- filename search remains the fastest path and stays single-digit millisecond
+  in this scoped release run
+- `rg`-backed content search is still responsive enough for scoped daily use
+- `git grep` fallback is slower than `rg` here but remains comfortably
+  interactive for repo-scoped queries
+
 ## Detailed Benchmark Results
 
 ### Test 1: Search for "main" (filename substring)
@@ -131,10 +152,10 @@ Compression Ratio     ~6.6:1 (estimated)
 
 | Feature                    | vicaya | find | grep | locate |
 |----------------------------|--------|------|------|--------|
-| Substring Search           | ✅ 6ms | ❌ 85ms | ❌ 677ms | ✅ ~5ms* |
-| Instant Results            | ✅ Yes | ❌ No | ❌ No | ✅ Yes |
-| Real-time Updates          | ✅ macOS | ✅ N/A | ✅ N/A | ❌ Periodic |
-| Content Search             | ❌ No  | ❌ No | ✅ Yes | ❌ No |
+| Filename Substring Search  | ✅ 6ms | ❌ 85ms | ❌ 677ms | ✅ ~5ms* |
+| Instant Filename Results   | ✅ Yes | ❌ No | ❌ No | ✅ Yes |
+| Real-time Filename Updates | ✅ macOS | ✅ N/A | ✅ N/A | ❌ Periodic |
+| Scoped Content Search      | ✅ rg-backed, git-grep/grep fallback | ❌ No | ✅ Yes | ❌ No |
 | Memory Usage (42 files)    | ✅ 11KB | ✅ 0KB | ✅ 0KB | ~20KB* |
 | Cross-platform             | ❌ macOS | ✅ Yes | ✅ Yes | ✅ Yes |
 
@@ -149,9 +170,11 @@ Compression Ratio     ~6.6:1 (estimated)
 - Keeps index updated via watcher + journal + periodic reconciliation
 
 ### vs. grep  
-- **112x faster** for filename searches
-- grep optimized for content, not filenames
-- Not a fair comparison for grep's use case
+- **112x faster** for indexed filename searches
+- Uses `rg` first for scoped content search, then `git grep`, with standard
+  `grep` available as an explicit slow fallback
+- Content search is intentionally scoped and on-demand; Vicaya does not maintain
+  a full-text index
 
 ### vs. locate/mlocate
 - Similar query performance (both index-based)
@@ -178,7 +201,11 @@ Compression Ratio     ~6.6:1 (estimated)
 
 ## Conclusions
 
-vicaya delivers on its "blazing-fast" promise with **consistently sub-10ms queries** and **10-100x performance advantages** over traditional tools for filename searches.
+vicaya delivers on its "blazing-fast" promise with **consistently sub-10ms
+indexed filename queries** and **10-100x performance advantages** over
+traditional tools for filename searches. Scoped content search now remains
+interactive through `rg`/`git grep` without expanding the daemon index into a
+full-text store.
 
 The trigram-based index provides:
 - Instant substring matching

--- a/docs/tasks/009-content-search-drishti.md
+++ b/docs/tasks/009-content-search-drishti.md
@@ -1,0 +1,37 @@
+# 009 - Content Search Drishti
+
+## Goal
+
+Add `Antarvicaya` content search for daily repo use without slowing filename search.
+
+## Plan
+
+1. Add a shared content-search engine in `vicaya-core`.
+   - Prefer `rg`.
+   - Fall back to `git grep` automatically inside a git worktree.
+   - Use plain recursive `grep` only when explicitly requested or enabled.
+2. Add `vicaya grep <query>`.
+   - Support `--scope`, `--limit`, `--format`, `--engine`, and `--allow-slow-fallback`.
+   - Emit JSON for scripts and compact table/plain output for terminals.
+3. Enable `Antarvicaya` in the TUI.
+   - Reuse the existing Drishti switcher, results list, preview pane, and scope stack.
+   - Show `file:line:column` rows and jump preview near the selected match.
+   - Surface a clear unavailable message when no safe engine exists.
+4. Verify.
+   - Unit and integration tests for engine parsing, fallback policy, CLI parsing, TUI preview anchors, and worker content results.
+   - `make check`.
+   - `hyperfine` against scoped repo searches.
+   - shux visual automation with desktop, narrow, wide, disabled-engine, and fallback screenshots.
+5. Ship.
+   - Update README, architecture, TUI plan, benchmark notes, and default config.
+   - Open a PR with screenshot comments and validation output.
+   - Run local dootsabha review, address relevant comments, then monitor CI/review.
+
+## Definition of Done
+
+- `vicaya grep` returns scoped content matches and does not require the daemon.
+- `Antarvicaya` is selectable from `Ctrl+T` and works with normal TUI navigation.
+- Missing `rg` degrades to `git grep` inside repos; slow `grep` fallback is explicit.
+- Filename search path remains unchanged and fast.
+- No TUI layout regressions in shux screenshots across tested sizes.
+- Relevant docs and config examples describe the feature and fallback policy.

--- a/docs/vicaya-tui-plan.md
+++ b/docs/vicaya-tui-plan.md
@@ -247,9 +247,9 @@ A `Drishti` is: **data source + ranking + row template + preview strategy + acti
 
 6. `Antarvicaya` (Content, Grep)
    - Default `Ksetra`: current dir / git root (avoid full disk by default)
-   - Source: streaming `ripgrep` results (`path:line:col` + snippet)
-   - Preview: file centered on match with highlight
-   - Actions: open at line/col, copy location, refine query into filename search, narrow scope
+   - Source: scoped content results (`path:line:col` + snippet) using `rg`, then `git grep`, with slow `grep` explicit
+   - Preview: file centered near match with query highlight
+   - Actions: open file, copy path, print path, reveal, narrow scope
 
 7. `Sanketa` (Symbols)
    - Default `Ksetra`: project scope
@@ -365,10 +365,12 @@ Shipped (Phase 3):
 - [x] Implement `Ksetra` stack with breadcrumbs + `Pravesha`/`Nirgama`
 - [x] Add `Niyama` chips (`type`, `ext`, `path`, minimal `mtime/size`)
 - [x] Add `Varga` grouping toggle (none / dir / ext) without losing ranking
+- [x] Implement `Antarvicaya` content search drishti with `rg` / `git grep` / explicit `grep` policy
 
 Next up (Phase 4):
 
-- [ ] Implement `Antarvicaya` (Grep) `Drishti` (scoped `rg` streaming results)
+- [ ] Add open-at-line editor integration for `Antarvicaya` matches
+- [ ] Add richer match-context preview windows for very large files
 
 ### Phase 0 — Spec Lock (1–3 days)
 
@@ -396,8 +398,8 @@ Next up (Phase 4):
 
 ### Phase 4 — `Antarvicaya` (Grep) Drishti (1–2 weeks)
 
-- `rg` streaming results in scoped mode by default.
-- Preview anchored to match; open-at-line actions.
+- Scoped content results in the existing worker pipeline.
+- Preview anchored near match; open-at-line actions remain a follow-up.
 - Optional hybrid “index-assisted grep” to narrow candidate set.
 
 ### Phase 5 — Differentiators (Ongoing)

--- a/docs/vicaya.md
+++ b/docs/vicaya.md
@@ -34,7 +34,7 @@ Note: This document began as an implementation plan; many checklists and timelin
 
 ### What We're Building
 
-vicaya (विचय) is a macOS developer file finder that locates files and folders by filename, path, and basic metadata *instantly*, with interactive results as you type. It mirrors the "Everything for Windows" experience but is terminal-native, Rust-powered, and designed to complement content search tools like `ripgrep`.
+vicaya (विचय) is a macOS developer file finder that locates files and folders by filename, path, and basic metadata *instantly*, with interactive results as you type. It mirrors the "Everything for Windows" experience but is terminal-native, Rust-powered, and can hand scoped content queries to local grep-class tools.
 
 ### Key Deliverables
 
@@ -49,6 +49,7 @@ vicaya (विचय) is a macOS developer file finder that locates files and fo
 - [x] **Search Frontends**
   - [x] CLI search tool (`vicaya`): instant results, filters, scripting-friendly.
   - [x] Terminal UI (`vicaya-tui`): interactive search-as-you-type.
+  - [x] Scoped content search (`vicaya grep`, `Antarvicaya` TUI drishti) via `rg` / `git grep` / explicit slow `grep`.
   - [ ] macOS menu-bar / quick-switch UI with global hotkey and result list.
 - [x] **Config & Preferences**
   - Exclusion rules, per-volume settings, performance knobs.
@@ -75,8 +76,8 @@ vicaya (विचय) is a macOS developer file finder that locates files and fo
 ### Constraints & Non-Goals
 
 - **Platform**: macOS only (APFS/HFS+). No Windows/Linux support in v1.
-- **Scope**: *Filename / path search only* in v1.
-  - No file content indexing (may be future plugin).
+- **Scope**: indexed filename / path search stays the primary v1 path.
+  - File contents are not indexed; scoped content search shells out to local tools.
 - **Permissions**: Respects macOS TCC (Full Disk Access). No bypasses.
 - **Non-goals (v1)**:
   - Network search across multiple machines.
@@ -223,11 +224,20 @@ RANK  SCORE  MODIFIED            PATH
 $ vicaya search "query.rs" --scope ~/code/github.com/example-repo --limit 5
 RANK  SCORE  MODIFIED            PATH
 1     1.00   2026-03-11 10:21    /Users/alice/code/github.com/example-repo/src/query.rs
+
+$ vicaya grep "fn main" --scope ~/code/github.com/example-repo --limit 5
+Engine: ripgrep
+RANK   LINE       COL      MATCH
+1      12         4        /Users/alice/code/github.com/example-repo/src/main.rs:12 fn main() {
 ```
 
 The shipped CLI now supports explicit subtree restriction via `--scope <DIR>`,
 while the TUI can be launched directly into a scope with `vicaya-tui .` or
-`vicaya-tui /some/dir`.
+`vicaya-tui /some/dir`. Content search is scoped and does not use the daemon:
+`engine = "auto"` prefers `rg`, then `git grep` inside a worktree. Plain
+recursive `grep` is available only by explicit request or slow-fallback config.
+Older `config.toml` files without `[content_search]` continue to load; the
+defaults are applied in memory rather than rewriting the file.
 
 ### State Transitions (High-Level)
 


### PR DESCRIPTION
## Summary

- add shared scoped content search with fast-first engine resolution (`rg` -> `git grep` -> explicit `grep`)
- add `vicaya grep` plus `Antarvicaya` TUI drishti with anchored preview and visible degradation errors
- document config defaults, existing-install behavior, shux visual proof, and hyperfine benchmark results

## Validation

- `make check`
- pre-push `make ci` via lefthook
- `.shux/scripts/content-search-visual.sh`
- `hyperfine --warmup 5 --runs 20` against release binaries
- release-binary smoke under `$HOME` and multiple repos under `~/code/github.com`
- `dootsabha review --json --timeout 10m` with relevant findings incorporated

## Screenshots

Screenshots will be added as PR comments from the final shux run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `vicaya grep` CLI command for scoped content search with configurable engines (ripgrep, git-grep, grep) and output formats (JSON, table, plain).
  * Added Antarvicaya content search view in TUI with preview anchoring to match locations.
  * Content search configuration with enable/disable toggle and automatic engine fallback.

* **Documentation**
  * Updated architecture guide, benchmarks, and implementation plans to document content search functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/indrasvat/vicaya/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->